### PR TITLE
Random Print Returned from a given specification

### DIFF
--- a/src/adapters/inbound/discord/utils/colours.rs
+++ b/src/adapters/inbound/discord/utils/colours.rs
@@ -39,3 +39,99 @@ fn get_colour_num(colour: &str) -> (u8, u8, u8) {
         _ => (0xF9, 0xC7, 0x4F),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mono_red_colour() {
+        let colour = get_colour_identity(&["R".to_string()]);
+        assert_eq!(colour.r(), 220);
+        assert_eq!(colour.g(), 20);
+        assert_eq!(colour.b(), 60);
+    }
+
+    #[test]
+    fn test_mono_blue_colour() {
+        let colour = get_colour_identity(&["U".to_string()]);
+        assert_eq!(colour.r(), 0x04);
+        assert_eq!(colour.g(), 0x92);
+        assert_eq!(colour.b(), 0xC2);
+    }
+
+    #[test]
+    fn test_azorius_colours() {
+        // White-Blue (Azorius)
+        let colour = get_colour_identity(&["U".to_string(), "W".to_string()]);
+        assert_eq!(colour.r(), 0x95);
+        assert_eq!(colour.g(), 0xB9);
+        assert_eq!(colour.b(), 0xDB);
+    }
+
+    #[test]
+    fn test_golgari_colours() {
+        // Black-Green (Golgari)
+        let colour = get_colour_identity(&["B".to_string(), "G".to_string()]);
+        assert_eq!(colour.r(), 0x06);
+        assert_eq!(colour.g(), 0x40);
+        assert_eq!(colour.b(), 0x2B);
+    }
+
+    #[test]
+    fn test_five_colour_card() {
+        // WUBRG (all five colors)
+        let colour = get_colour_identity(&[
+            "B".to_string(),
+            "G".to_string(),
+            "R".to_string(),
+            "U".to_string(),
+            "W".to_string(),
+        ]);
+        // Should be white (all colors)
+        assert_eq!(colour.r(), 0xFF);
+        assert_eq!(colour.g(), 0xFF);
+        assert_eq!(colour.b(), 0xFF);
+    }
+
+    #[test]
+    fn test_colorless_card() {
+        let colour = get_colour_identity(&[]);
+        // Should be gray (colorless)
+        assert_eq!(colour.r(), 0xA9);
+        assert_eq!(colour.g(), 0xA9);
+        assert_eq!(colour.b(), 0xA9);
+    }
+
+    #[test]
+    fn test_unknown_colour_combination() {
+        // Test that unknown combinations get the gold/multicolor default
+        let colour = get_colour_identity(&["X".to_string(), "Y".to_string()]);
+        assert_eq!(colour.r(), 0xF9);
+        assert_eq!(colour.g(), 0xC7);
+        assert_eq!(colour.b(), 0x4F);
+    }
+
+    #[test]
+    fn test_bant_colours() {
+        // White-Blue-Green (Bant)
+        let colour = get_colour_identity(&["G".to_string(), "U".to_string(), "W".to_string()]);
+        assert_eq!(colour.r(), 0x81);
+        assert_eq!(colour.g(), 0xFF);
+        assert_eq!(colour.b(), 0xFF);
+    }
+
+    #[test]
+    fn test_colour_identity_joins_correctly() {
+        // Test that the join operation works as expected
+        let single = get_colour_identity(&["R".to_string()]);
+        let double = get_colour_identity(&["G".to_string(), "R".to_string()]);
+
+        // Single should be mono-red
+        assert_eq!(single.r(), 220);
+
+        // Double should be Gruul
+        assert_eq!(double.r(), 0x89);
+    }
+}
+

--- a/src/adapters/outbound/card_store/postgres/queries.rs
+++ b/src/adapters/outbound/card_store/postgres/queries.rs
@@ -49,7 +49,7 @@ from card front
          left join set on set.id = front.set_id
          left join price on front.id = price.id
 where front.normalised_name % $1
-order by front.oracle_id, front.release_date desc;
+order by front.oracle_id, random() desc;
 ";
 
 pub const FUZZY_SEARCH_CARD_AND_SET_NAME: &str = r"
@@ -106,7 +106,7 @@ from card front
          left join price on front.id = price.id
 where front.normalised_name % $1
   and set.normalised_name % $2
-order by front.oracle_id, set_sml desc;
+order by front.oracle_id, set_sml, random() desc;
 ";
 
 pub const FUZZY_SEARCH_CARD_AND_ARTIST: &str = r"
@@ -163,7 +163,7 @@ from card front
          left join price on front.id = price.id
 where front.normalised_name % $1
   and artist.normalised_name % $2
-order by front.oracle_id, artist_sml desc;
+order by front.oracle_id, artist_sml, random() desc;
 ";
 
 pub const FUZZY_SEARCH_SET_NAME: &str = r"


### PR DESCRIPTION
As some cards have multiple versions from a given set or artist returning a random choice from the specified versions allows return of images that wont have been seen before.

Also returning a random version from fuzzy match gives more visual variety rather than returning only the newest version of a card. 