### PR TITLE
Fix wrong card returned for double-faced cards

### DIFF
--- a/packages/bot/src/adapters/drivers/discord/commands/game.rs
+++ b/packages/bot/src/adapters/drivers/discord/commands/game.rs
@@ -28,7 +28,7 @@ impl GameInteraction for DiscordCommandInteraction {
         guess: String,
     ) -> Result<(), MessageInteractionError> {
         let illustration = if let Some(illustration_id) = state.card().illustration_id() {
-            CreateAttachment::bytes(images.bytes(), format!("{illustration_id}.png",))
+            CreateAttachment::bytes(images.bytes(), format!("{illustration_id}.png"))
         } else {
             log::warn!("Card had no illustration id");
             return Err(MessageInteractionError::new(String::from(
@@ -72,7 +72,7 @@ impl GameInteraction for DiscordCommandInteraction {
         };
 
         let illustration =
-            CreateAttachment::bytes(images.bytes(), format!("{illustration_id}.png",));
+            CreateAttachment::bytes(images.bytes(), format!("{illustration_id}.png"));
         let difficulty = state.difficulty();
         let set_name = state.card().set_name();
         let message = match difficulty {

--- a/packages/bot/src/adapters/services/card_store/postgres/mod.rs
+++ b/packages/bot/src/adapters/services/card_store/postgres/mod.rs
@@ -160,9 +160,10 @@ impl CardStore for Postgres {
         }
     }
 
-    async fn similar_cards(&self, normalised_name: &str) -> Option<Vec<Card>> {
+    async fn similar_cards(&self, card: &Card) -> Option<Vec<Card>> {
         match sqlx::query(SIMILAR_CARDS_FROM)
-            .bind(normalised_name)
+            .bind(card.normalised_name())
+            .bind(card.oracle_id())
             .fetch_all(&self.pool)
             .await
         {

--- a/packages/bot/src/adapters/services/card_store/postgres/queries.rs
+++ b/packages/bot/src/adapters/services/card_store/postgres/queries.rs
@@ -231,6 +231,6 @@ from card
          left join rule on card.oracle_id = rule.id
          left join artist on card.artist_id = artist.id
          left join set on set.id = card.set_id
-where card.normalised_name % $1 and card.normalised_name != $1
+where card.normalised_name % $1 and card.oracle_id != $2
 order by card.oracle_id desc;
 ";

--- a/packages/bot/src/adapters/services/image_store/file_system.rs
+++ b/packages/bot/src/adapters/services/image_store/file_system.rs
@@ -42,7 +42,7 @@ impl ImageStore for FileSystem {
             )));
         };
 
-        let bytes = tokio::fs::read(format!("{}{}.png", self.illustration_dir, illustration_id,))
+        let bytes = tokio::fs::read(format!("{}{}.png", self.illustration_dir, illustration_id))
             .await
             .map_err(|_| {
                 ImageRetrievalError::new(format!("No illustration found for {}", card.name()))

--- a/packages/bot/src/domain/search.rs
+++ b/packages/bot/src/domain/search.rs
@@ -1,11 +1,11 @@
 use crate::domain::app::App;
 use crate::domain::query::QueryParams;
+use crate::domain::utils::card_picking::extract_match;
 use crate::domain::utils::REGEX_COLLECTION;
 use crate::ports::drivers::client::MessageInteraction;
 use crate::ports::services::cache::Cache;
 use crate::ports::services::card_store::CardStore;
 use crate::ports::services::image_store::ImageStore;
-use crate::domain::utils::card_picking::extract_match;
 use contracts::card::Card;
 use contracts::search_result::SearchResultDto;
 use fuzzy;
@@ -103,14 +103,14 @@ where
     pub async fn fetch_from_id(&self, card_id: &Uuid) -> Option<SearchResultDto> {
         let start = Instant::now();
         let card = self.card_store.fetch_card_by_id(card_id).await?;
-        let similar_cards = self
-            .card_store
-            .similar_cards(card.normalised_name())
-            .await?;
-        let (sets, images) = tokio::join!(
+
+        let (sets, images, similar_cards) = tokio::join!(
             self.card_store.all_prints(card.oracle_id()),
             self.image_store.fetch(&card),
+            self.card_store.similar_cards(&card),
         );
+
+        let similar_cards = fuzzy::winkliest_sort(&card.normalised_name(), similar_cards?);
         log::info!("Fetch new print in {}ms", start.elapsed().as_millis());
         Some(
             SearchResultDto::new(card, images.ok()?)

--- a/packages/bot/src/domain/search.rs
+++ b/packages/bot/src/domain/search.rs
@@ -5,6 +5,7 @@ use crate::ports::drivers::client::MessageInteraction;
 use crate::ports::services::cache::Cache;
 use crate::ports::services::card_store::CardStore;
 use crate::ports::services::image_store::ImageStore;
+use crate::domain::utils::card_picking::extract_match;
 use contracts::card::Card;
 use contracts::search_result::SearchResultDto;
 use fuzzy;
@@ -78,9 +79,7 @@ where
             return None;
         }
 
-        let mut found_cards_sorted = fuzzy::winkliest_sort(&query.name(), found_cards);
-
-        let found_card = found_cards_sorted.drain(0..1).next()?;
+        let (found_card, discarded) = extract_match(found_cards, query.name())?;
 
         log::info!(
             "Found match for query '{}' -> '{}' in {} ms",
@@ -97,7 +96,7 @@ where
         Some(
             SearchResultDto::new(found_card, images.ok()?)
                 .add_printings(sets)
-                .add_similar_cards(found_cards_sorted),
+                .add_similar_cards(discarded),
         )
     }
 

--- a/packages/bot/src/domain/utils/card_picking.rs
+++ b/packages/bot/src/domain/utils/card_picking.rs
@@ -1,5 +1,6 @@
 use contracts::card::Card;
 
+#[must_use]
 pub fn extract_match(haystack: Vec<Card>, needle: &str) -> Option<(Card, Vec<Card>)> {
     let mut found_cards_sorted = fuzzy::winkliest_sort(&needle, haystack);
 
@@ -42,7 +43,7 @@ mod tests {
             id,
             String::new(),
             id,
-            None,        // illustration_id
+            None, // illustration_id
             String::new(),
             vec![],
             None,
@@ -51,7 +52,7 @@ mod tests {
             None,
             String::new(),
             String::new(),
-            back_id,     // back_id
+            back_id, // back_id
             String::new(),
             String::new(),
         )
@@ -64,7 +65,11 @@ mod tests {
 
     #[test]
     fn single_card_no_backside_is_returned() {
-        let card = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", None);
+        let card = make_card(
+            uuid!("00000000-0000-0000-0000-000000000001"),
+            "Lightning Bolt",
+            None,
+        );
         let (found, discarded) = extract_match(vec![card], "lightning bolt").unwrap();
         assert_eq!(found.name(), "Lightning Bolt");
         assert!(found.back_id().is_none());
@@ -73,7 +78,11 @@ mod tests {
 
     #[test]
     fn single_card_with_backside_is_returned() {
-        let card = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", Some(BACK_UUID));
+        let card = make_card(
+            uuid!("00000000-0000-0000-0000-000000000001"),
+            "Lightning Bolt",
+            Some(BACK_UUID),
+        );
         let (found, discarded) = extract_match(vec![card], "lightning bolt").unwrap();
         assert_eq!(found.name(), "Lightning Bolt");
         assert!(found.back_id().is_some());
@@ -82,8 +91,16 @@ mod tests {
 
     #[test]
     fn first_card_no_backside_returned_without_entering_loop() {
-        let bolt = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", None);
-        let rift = make_card(uuid!("00000000-0000-0000-0000-000000000002"), "Lightning Rift", None);
+        let bolt = make_card(
+            uuid!("00000000-0000-0000-0000-000000000001"),
+            "Lightning Bolt",
+            None,
+        );
+        let rift = make_card(
+            uuid!("00000000-0000-0000-0000-000000000002"),
+            "Lightning Rift",
+            None,
+        );
         let (found, discarded) = extract_match(vec![bolt, rift], "lightning bolt").unwrap();
         assert_eq!(found.name(), "Lightning Bolt");
         assert!(found.back_id().is_none());
@@ -92,9 +109,18 @@ mod tests {
 
     #[test]
     fn prefers_same_named_card_without_backside() {
-        let with_back = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", Some(BACK_UUID));
-        let without_back = make_card(uuid!("00000000-0000-0000-0000-000000000002"), "Lightning Bolt", None);
-        let (found, discarded) = extract_match(vec![with_back, without_back], "lightning bolt").unwrap();
+        let with_back = make_card(
+            uuid!("00000000-0000-0000-0000-000000000001"),
+            "Lightning Bolt",
+            Some(BACK_UUID),
+        );
+        let without_back = make_card(
+            uuid!("00000000-0000-0000-0000-000000000002"),
+            "Lightning Bolt",
+            None,
+        );
+        let (found, discarded) =
+            extract_match(vec![with_back, without_back], "lightning bolt").unwrap();
         assert!(found.back_id().is_none());
         assert_eq!(discarded.len(), 1);
         assert!(discarded[0].back_id().is_some());
@@ -102,8 +128,16 @@ mod tests {
 
     #[test]
     fn returns_first_when_all_same_named_cards_have_backsides() {
-        let back1 = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", Some(BACK_UUID));
-        let back2 = make_card(uuid!("00000000-0000-0000-0000-000000000002"), "Lightning Bolt", Some(BACK_UUID));
+        let back1 = make_card(
+            uuid!("00000000-0000-0000-0000-000000000001"),
+            "Lightning Bolt",
+            Some(BACK_UUID),
+        );
+        let back2 = make_card(
+            uuid!("00000000-0000-0000-0000-000000000002"),
+            "Lightning Bolt",
+            Some(BACK_UUID),
+        );
         let (found, discarded) = extract_match(vec![back1, back2], "lightning bolt").unwrap();
         assert!(found.back_id().is_some());
         assert_eq!(discarded.len(), 1);
@@ -111,8 +145,16 @@ mod tests {
 
     #[test]
     fn backside_preference_does_not_cross_name_boundary() {
-        let bolt = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", Some(BACK_UUID));
-        let recall = make_card(uuid!("00000000-0000-0000-0000-000000000002"), "Ancestral Recall", None);
+        let bolt = make_card(
+            uuid!("00000000-0000-0000-0000-000000000001"),
+            "Lightning Bolt",
+            Some(BACK_UUID),
+        );
+        let recall = make_card(
+            uuid!("00000000-0000-0000-0000-000000000002"),
+            "Ancestral Recall",
+            None,
+        );
         let (found, discarded) = extract_match(vec![bolt, recall], "lightning bolt").unwrap();
         assert_eq!(found.name(), "Lightning Bolt");
         assert!(found.back_id().is_some());

--- a/packages/bot/src/domain/utils/card_picking.rs
+++ b/packages/bot/src/domain/utils/card_picking.rs
@@ -1,0 +1,121 @@
+use contracts::card::Card;
+
+pub fn extract_match(haystack: Vec<Card>, needle: &str) -> Option<(Card, Vec<Card>)> {
+    let mut found_cards_sorted = fuzzy::winkliest_sort(&needle, haystack);
+
+    let found_index: usize = {
+        let top_card = found_cards_sorted.first()?;
+        if top_card.back_id().is_none() {
+            0
+        } else {
+            let top_name = top_card.name();
+            let mut result = None;
+            for (i, card) in found_cards_sorted.iter().skip(1).enumerate() {
+                if card.name() != top_name {
+                    break;
+                }
+                if card.back_id().is_none() {
+                    result = Some(i + 1);
+                    break;
+                }
+            }
+            result.unwrap_or(0)
+        }
+    };
+
+    let found_card = found_cards_sorted.remove(found_index);
+    Some((found_card, found_cards_sorted))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::{uuid, Uuid};
+
+    const BACK_UUID: Uuid = uuid!("ffffffff-ffff-ffff-ffff-ffffffffffff");
+
+    fn make_card(id: Uuid, name: &str, back_id: Option<Uuid>) -> Card {
+        Card::new(
+            id,
+            name.to_string(),
+            name.to_lowercase(),
+            id,
+            String::new(),
+            id,
+            None,        // illustration_id
+            String::new(),
+            vec![],
+            None,
+            None,
+            None,
+            None,
+            String::new(),
+            String::new(),
+            back_id,     // back_id
+            String::new(),
+            String::new(),
+        )
+    }
+
+    #[test]
+    fn returns_none_for_empty_haystack() {
+        assert!(extract_match(vec![], "lightning bolt").is_none());
+    }
+
+    #[test]
+    fn single_card_no_backside_is_returned() {
+        let card = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", None);
+        let (found, discarded) = extract_match(vec![card], "lightning bolt").unwrap();
+        assert_eq!(found.name(), "Lightning Bolt");
+        assert!(found.back_id().is_none());
+        assert!(discarded.is_empty());
+    }
+
+    #[test]
+    fn single_card_with_backside_is_returned() {
+        let card = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", Some(BACK_UUID));
+        let (found, discarded) = extract_match(vec![card], "lightning bolt").unwrap();
+        assert_eq!(found.name(), "Lightning Bolt");
+        assert!(found.back_id().is_some());
+        assert!(discarded.is_empty());
+    }
+
+    #[test]
+    fn first_card_no_backside_returned_without_entering_loop() {
+        let bolt = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", None);
+        let rift = make_card(uuid!("00000000-0000-0000-0000-000000000002"), "Lightning Rift", None);
+        let (found, discarded) = extract_match(vec![bolt, rift], "lightning bolt").unwrap();
+        assert_eq!(found.name(), "Lightning Bolt");
+        assert!(found.back_id().is_none());
+        assert_eq!(discarded.len(), 1);
+    }
+
+    #[test]
+    fn prefers_same_named_card_without_backside() {
+        let with_back = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", Some(BACK_UUID));
+        let without_back = make_card(uuid!("00000000-0000-0000-0000-000000000002"), "Lightning Bolt", None);
+        let (found, discarded) = extract_match(vec![with_back, without_back], "lightning bolt").unwrap();
+        assert!(found.back_id().is_none());
+        assert_eq!(discarded.len(), 1);
+        assert!(discarded[0].back_id().is_some());
+    }
+
+    #[test]
+    fn returns_first_when_all_same_named_cards_have_backsides() {
+        let back1 = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", Some(BACK_UUID));
+        let back2 = make_card(uuid!("00000000-0000-0000-0000-000000000002"), "Lightning Bolt", Some(BACK_UUID));
+        let (found, discarded) = extract_match(vec![back1, back2], "lightning bolt").unwrap();
+        assert!(found.back_id().is_some());
+        assert_eq!(discarded.len(), 1);
+    }
+
+    #[test]
+    fn backside_preference_does_not_cross_name_boundary() {
+        let bolt = make_card(uuid!("00000000-0000-0000-0000-000000000001"), "Lightning Bolt", Some(BACK_UUID));
+        let recall = make_card(uuid!("00000000-0000-0000-0000-000000000002"), "Ancestral Recall", None);
+        let (found, discarded) = extract_match(vec![bolt, recall], "lightning bolt").unwrap();
+        assert_eq!(found.name(), "Lightning Bolt");
+        assert!(found.back_id().is_some());
+        assert_eq!(discarded[0].name(), "Ancestral Recall");
+    }
+}

--- a/packages/bot/src/domain/utils/mod.rs
+++ b/packages/bot/src/domain/utils/mod.rs
@@ -1,3 +1,5 @@
+pub mod card_picking;
+
 use regex::Regex;
 use std::sync::LazyLock;
 use unicode_normalization::UnicodeNormalization;

--- a/packages/bot/src/ports/services/card_store.rs
+++ b/packages/bot/src/ports/services/card_store.rs
@@ -19,5 +19,5 @@ pub trait CardStore {
     async fn random_card_from_set(&self, set_name: &str) -> Option<Card>;
     async fn all_prints(&self, oracle_id: &Uuid) -> Option<Vec<Set>>;
     async fn fetch_card_by_id(&self, id: &Uuid) -> Option<Card>;
-    async fn similar_cards(&self, normalised_name: &str) -> Option<Vec<Card>>;
+    async fn similar_cards(&self, card: &Card) -> Option<Vec<Card>>;
 }

--- a/packages/fuzzy/src/lib.rs
+++ b/packages/fuzzy/src/lib.rs
@@ -123,7 +123,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_jaro_winkler_bitmasl() {
+    fn test_jaro_winkler_bitmask() {
         let a = "CRATE";
         let b = "TRACE";
 


### PR DESCRIPTION
  # Summary

  - Extracts card selection logic into a dedicated extract_match function that prefers single-faced cards when multiple results share the same name
  - When the best fuzzy match is a double-faced card, the function walks same-named candidates to find a single-faced version before falling back to the top scorer
  - The selected card is removed from the candidates list so the remaining discarded cards accurately reflect similar-but-rejected results

  # Test plan

  - cargo test card_picking — 7 unit tests covering: empty input, single card with/without backside, early exit when top card is clean, preference for same-named single-faced card, all-backside fallback, and name-boundary stopping behaviour
  - cargo test — full suite passes