### PR TITLE
Sync MTG set symbols as Discord application emojis

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           kubectl create secret generic app-secrets \
             --from-literal=BOT_TOKEN=${{ secrets.BOT_TOKEN }} \
+            --from-literal=APPLICATION_ID=${{ secrets.APPLICATION_ID }} \
             --from-literal=POSTGRES_USER=${{ secrets.POSTGRES_USER }} \
             --from-literal=POSTGRES_PW=${{ secrets.POSTGRES_PW }} \
             --from-literal=POSTGRES_DB=${{ secrets.POSTGRES_DB }} \

--- a/k8s/db-management.yaml
+++ b/k8s/db-management.yaml
@@ -81,6 +81,16 @@ spec:
                       key: POSTGRES_HOST
                 - name: IMAGES_DIR
                   value: /var/mtg_cards
+                - name: BOT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: app-secrets
+                      key: BOT_TOKEN
+                - name: APPLICATION_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: app-secrets
+                      key: APPLICATION_ID
               volumeMounts:
                 - name: images
                   mountPath: /var/mtg_cards

--- a/packages/db/.gitignore
+++ b/packages/db/.gitignore
@@ -181,6 +181,7 @@ junit.xml
 default-cards*.json
 oracle-cards*.json
 unique-artwork*.json
+sets-*.json
 
 # Random Files
 todo.txt

--- a/packages/db/Dockerfile
+++ b/packages/db/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.14-slim AS builder
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends libcairo2 && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -11,6 +11,8 @@ COPY ./packages ./packages/
 RUN uv sync --package db-management --frozen --no-dev
 
 FROM python:3.14-slim AS prod
+
+RUN apt-get update && apt-get install -y --no-install-recommends libcairo2 && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/packages/db/pyproject.toml
+++ b/packages/db/pyproject.toml
@@ -5,7 +5,6 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
-    "aiofiles>=24.1.0",
     "aiohttp>=3.13.3",
     "asyncpg>=0.31.0",
     "pydantic>=2.12.5",
@@ -15,6 +14,7 @@ dependencies = [
     "alembic (>=1.16.4,<2.0.0)",
     "anyio (>=4.12.1,<5)",
     "greenlet>=3.3.2",
+    "anyio==4.13.0",
 ]
 
 [tool.uv]

--- a/packages/db/pyproject.toml
+++ b/packages/db/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "anyio (>=4.12.1,<5)",
     "greenlet>=3.3.2",
     "anyio==4.13.0",
+    "cairosvg>=2.7.0",
 ]
 
 [tool.uv]

--- a/packages/db/src/main.py
+++ b/packages/db/src/main.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 import asyncpg
-from db.insert import insert_data
 from dotenv import load_dotenv
 from utils.data import load_scryfall_data
 from utils.images import download_missing_images
@@ -15,9 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 async def main() -> None:
-    data = await load_scryfall_data()
-    if not data:
+    card_data, set_data = await load_scryfall_data()
+    if not card_data:
         logger.error("Scryfall data could not be loaded.")
+        sys.exit(1)
+
+    if not set_data:
+        logger.error("Setting data could not be loaded.")
         sys.exit(1)
 
     user = os.getenv("POSTGRES_USER")
@@ -26,16 +29,16 @@ async def main() -> None:
     db = os.getenv("POSTGRES_DB")
     uri = f"postgresql://{user}:{password}@{host}/{db}"
     async with asyncpg.create_pool(dsn=uri) as pool:
-        data = tuple(
-            card
-            for card in data
-            if card.get("set_type") != "memorabilia"
-            and card.get("image_uris", {}).get("png") != "https://errors.scryfall.com/soon.jpg"
-        )
+        # card_data = tuple(
+        #     card
+        #     for card in card_data
+        #     if card.get("set_type") != "memorabilia"
+        #     and card.get("image_uris", {}).get("png") != "https://errors.scryfall.com/soon.jpg"
+        # )
+        #
+        # await insert_data(card_data, pool)
 
-        await insert_data(data, pool)
-
-        await download_missing_images(pool)
+        await download_missing_images(pool, set_data)
 
 
 if __name__ == "__main__":

--- a/packages/db/src/main.py
+++ b/packages/db/src/main.py
@@ -4,8 +4,10 @@ import os
 import sys
 
 import asyncpg
+from db.insert import insert_data
 from dotenv import load_dotenv
 from utils.data import load_scryfall_data
+from utils.emojis import sync_set_symbol_emojis
 from utils.images import download_missing_images
 
 load_dotenv()
@@ -29,16 +31,17 @@ async def main() -> None:
     db = os.getenv("POSTGRES_DB")
     uri = f"postgresql://{user}:{password}@{host}/{db}"
     async with asyncpg.create_pool(dsn=uri) as pool:
-        # card_data = tuple(
-        #     card
-        #     for card in card_data
-        #     if card.get("set_type") != "memorabilia"
-        #     and card.get("image_uris", {}).get("png") != "https://errors.scryfall.com/soon.jpg"
-        # )
-        #
-        # await insert_data(card_data, pool)
+        card_data = tuple(
+            card
+            for card in card_data
+            if card.get("set_type") != "memorabilia"
+            and card.get("image_uris", {}).get("png") != "https://errors.scryfall.com/soon.jpg"
+        )
+
+        await insert_data(card_data, pool)
 
         await download_missing_images(pool, set_data)
+        await sync_set_symbol_emojis()
 
 
 if __name__ == "__main__":

--- a/packages/db/src/sets/get.py
+++ b/packages/db/src/sets/get.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+async def download() -> list[dict[str, Any]]:
+    pass

--- a/packages/db/src/sets/get.py
+++ b/packages/db/src/sets/get.py
@@ -1,5 +1,0 @@
-from typing import Any
-
-
-async def download() -> list[dict[str, Any]]:
-    pass

--- a/packages/db/src/utils/data.py
+++ b/packages/db/src/utils/data.py
@@ -1,20 +1,21 @@
+import asyncio
 import json
 import logging
 import os
 import re
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
-from typing import Self
+from typing import Any, Self
 
-import aiofiles
 import aiohttp
 from aiohttp import ClientResponse
+from anyio import Path
 from dotenv import load_dotenv
 
 load_dotenv()
 
 logger = logging.getLogger(__name__)
 file_regex = re.compile(r"default-cards-(\d+\+\d{4})\.json")
+set_file_regex = re.compile(r"sets-(\d+\+\d{4})\.json")
 DATE_FORMAT = "%Y%m%d%H%M%S%z"
 
 
@@ -39,61 +40,81 @@ class DateCache:
         )
 
 
-def look_for_data_file() -> str | None:
+async def look_for_card_data_file(rx: re.Pattern) -> Path | None:
     return_file = None
-    for file in Path().iterdir():
-        if match := file_regex.match(file.name):
+    async for file in Path().iterdir():
+        if match := rx.match(file.name):
             date = datetime.strptime(match.group(1), DATE_FORMAT)
             date_cache.date = date
             if date < (datetime.now(tz=timezone.utc) - timedelta(days=6, hours=23)):
                 logger.info(f"Deleting stale card data: {file.name}")
-                file.unlink()
+                await file.unlink()
             else:
                 return_file = file
 
     return return_file
 
 
-async def load_data_file(data_file: str | Path) -> list[dict]:
-    async with aiofiles.open(data_file, encoding="utf-8") as file:
-        return json.loads(await file.read())
+async def load_data_file(data_file: Path) -> list[dict]:
+    return json.loads(await data_file.read_text())
 
 
-async def download_scryfall_data() -> list[dict] | None:
-    logger.info("Downloading from Scryfall")
+async def download_scryfall_set_data() -> list[dict[str, Any]] | None:
+    logger.info("Downloading scryfall set data.")
     async with aiohttp.ClientSession() as session:
-        response = await session.get("https://api.scryfall.com/bulk-data")
-        date_cache.extract_datetime(response)
-        bulk_data_info = await response.json()
+        sets_response = await session.get("https://api.scryfall.com/sets")
+        date_cache.extract_datetime(sets_response)
+        data = await sets_response.json()
+
+    if data := data.get("data"):
+        await Path(f"sets-{date_cache.date.strftime(DATE_FORMAT)}.json").write_text(json.dumps(data))
+
+        return data
+
+    return None
+
+
+async def download_scryfall_card_data() -> list[dict] | None:
+    logger.info("Downloading cards from Scryfall")
+    async with aiohttp.ClientSession() as session:
+        cards_response = await session.get("https://api.scryfall.com/bulk-data")
+        date_cache.extract_datetime(cards_response)
+        bulk_data_info = await cards_response.json()
 
         for category in bulk_data_info["data"]:
             if category["type"] == "default_cards":
-                response = await session.get(category["download_uri"])
-                data = await response.json()
+                cards_response = await session.get(category["download_uri"])
+                data = await cards_response.json()
 
                 if os.getenv("DEV"):
-                    async with aiofiles.open(
-                        f"default-cards-{date_cache.date.strftime(DATE_FORMAT)}.json",
-                        "w",
-                        encoding="utf-8",
-                    ) as file:
-                        await file.write(json.dumps(data))
+                    cards_path = Path(f"default-cards-{date_cache.date.strftime(DATE_FORMAT)}.json")
+                    await cards_path.write_text(json.dumps(data))
 
                 return data
 
         return None
 
 
-async def load_scryfall_data() -> list[dict] | None:
+async def load_scryfall_data() -> tuple[list[dict] | None, list[dict[str, Any]] | None]:
+    card_loader = None
     if data_file := os.getenv("FILE"):
         logger.info("Found file specified by environment variables.")
-        return await load_data_file(data_file)
+        card_loader = load_data_file(Path(data_file))
 
-    if (data_file := look_for_data_file()) and os.getenv("DEV"):
-        logger.info("Found cached data from previous download less than a week old.")
-        return await load_data_file(data_file)
+    if (data_file := await look_for_card_data_file(file_regex)) and os.getenv("DEV"):
+        logger.info("Found cached card data from previous download less than a week old.")
+        card_loader = load_data_file(data_file)
 
-    return await download_scryfall_data()
+    if not card_loader:
+        card_loader = download_scryfall_card_data()
+
+    if (data_file := await look_for_card_data_file(set_file_regex)) and os.getenv("DEV"):
+        logger.info("Found cached set data from previous download less than a week old.")
+        sets_loader = load_data_file(data_file)
+    else:
+        sets_loader = download_scryfall_set_data()
+
+    return await asyncio.gather(card_loader, sets_loader)
 
 
 date_cache = DateCache()

--- a/packages/db/src/utils/emojis.py
+++ b/packages/db/src/utils/emojis.py
@@ -1,0 +1,118 @@
+import asyncio
+import base64
+import logging
+import os
+
+from aiohttp import ClientSession, TCPConnector
+from anyio import Path
+from dotenv import load_dotenv
+from tqdm import tqdm
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+DISCORD_API = "https://discord.com/api/v10"
+# Application emojis are capped at 2000; MTG has ~900+ sets so we log a warning if we approach that.
+EMOJI_LIMIT = 2000
+
+
+def _sanitize_name(name: str) -> str:
+    """Discord emoji names: 2-32 chars, alphanumeric + underscores only."""
+    sanitized = "".join(c if c.isalnum() or c == "_" else "_" for c in name)
+    if len(sanitized) < 2:
+        sanitized = sanitized + "_"
+    return sanitized[:32]
+
+
+async def _fetch_existing_emojis(session: ClientSession, application_id: str) -> set[str]:
+    url = f"{DISCORD_API}/applications/{application_id}/emojis"
+    response = await session.get(url)
+    if response.status != 200:
+        text = await response.text()
+        logger.error(f"Failed to fetch existing emojis: {response.status} {text}")
+        return set()
+
+    data = await response.json()
+    return {item["name"] for item in data.get("items", [])}
+
+
+async def _upload_emoji(
+    session: ClientSession,
+    application_id: str,
+    name: str,
+    png_path: Path,
+    pbar: tqdm,
+    semaphore: asyncio.Semaphore,
+) -> None:
+    async with semaphore:
+        png_bytes = await png_path.read_bytes()
+        encoded = base64.b64encode(png_bytes).decode()
+        payload = {"name": name, "image": f"data:image/png;base64,{encoded}"}
+
+        url = f"{DISCORD_API}/applications/{application_id}/emojis"
+        response = await session.post(url, json=payload)
+
+        if response.status == 201:
+            logger.debug(f"Uploaded emoji: {name}")
+        elif response.status == 429:
+            retry_after = (await response.json()).get("retry_after", 1.0)
+            logger.warning(f"Rate limited uploading {name}, retrying after {retry_after}s")
+            await asyncio.sleep(retry_after)
+            # Re-attempt once after backoff
+            response = await session.post(url, json=payload)
+            if response.status != 201:
+                logger.error(f"Failed to upload emoji {name} after retry: {response.status}")
+        else:
+            text = await response.text()
+            logger.error(f"Failed to upload emoji {name}: {response.status} {text}")
+
+        pbar.update()
+
+
+async def sync_set_symbol_emojis() -> None:
+    bot_token = os.getenv("BOT_TOKEN")
+    application_id = os.getenv("APPLICATION_ID")
+    images_dir = os.getenv("IMAGES_DIR")
+
+    if not bot_token or not application_id or not images_dir:
+        logger.error("BOT_TOKEN, APPLICATION_ID, and IMAGES_DIR must be set to sync emojis")
+        return
+
+    sets_dir = Path(images_dir) / "sets"
+    if not await sets_dir.exists():
+        logger.warning("Sets directory not found, skipping emoji sync")
+        return
+
+    headers = {"Authorization": f"Bot {bot_token}"}
+    connector = TCPConnector(limit=3)
+    async with ClientSession(headers=headers, connector=connector) as session:
+        existing = await _fetch_existing_emojis(session, application_id)
+        logger.info(f"Found {len(existing)} existing application emojis")
+
+        png_files = [f async for f in sets_dir.iterdir() if f.name.endswith(".png")]
+        to_upload = []
+        for png_path in png_files:
+            name = _sanitize_name(png_path.stem)
+            if name not in existing:
+                to_upload.append((name, png_path))
+
+        logger.info(f"Uploading {len(to_upload)} new set symbol emojis")
+
+        if len(existing) + len(to_upload) > EMOJI_LIMIT:
+            logger.warning(
+                f"Would exceed Discord emoji limit ({EMOJI_LIMIT}). "
+                f"Truncating to {EMOJI_LIMIT - len(existing)} uploads."
+            )
+            to_upload = to_upload[: EMOJI_LIMIT - len(existing)]
+
+        if not to_upload:
+            logger.info("All set symbol emojis are already synced")
+            return
+
+        semaphore = asyncio.Semaphore(3)
+        with tqdm(total=len(to_upload)) as pbar:
+            pbar.set_description("Uploading set symbol emojis")
+            await asyncio.gather(
+                *(_upload_emoji(session, application_id, name, path, pbar, semaphore) for name, path in to_upload)
+            )

--- a/packages/db/src/utils/images.py
+++ b/packages/db/src/utils/images.py
@@ -3,7 +3,6 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-import aiofiles
 from aiohttp import ClientSession, ClientTimeout, TCPConnector
 from anyio import Path
 from dotenv import load_dotenv
@@ -41,8 +40,7 @@ async def fetch_image(record: Record, session: ClientSession, pbar: tqdm, direct
             pbar.update()
             return
 
-        async with aiofiles.open(proposed_path, "wb") as f:
-            await f.write(png)
+        await Path(proposed_path).write_bytes(png)
 
     pbar.update()
 

--- a/packages/db/src/utils/images.py
+++ b/packages/db/src/utils/images.py
@@ -88,7 +88,7 @@ async def download_missing_illustrations(pool: Pool, base_dir: Path) -> None:
 
 
 async def symbol_present(data: dict[str, Any], base_dir: Path) -> bool:
-    if not (identifier := data.get("id")):
+    if not (identifier := data.get("code")):
         return True
 
     return await (base_dir / f"{identifier}.png").exists()
@@ -108,7 +108,7 @@ async def download_and_convert_symbol(
         pbar.update()
         return
 
-    identifier: str | None = data.get("id")
+    identifier: str | None = data.get("code")
     svg_url: str | None = data.get("icon_svg_uri")
 
     if not identifier or not svg_url:

--- a/packages/db/src/utils/images.py
+++ b/packages/db/src/utils/images.py
@@ -1,8 +1,10 @@
+import asyncio
 import contextlib
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+import cairosvg
 from aiohttp import ClientSession, ClientTimeout, TCPConnector
 from anyio import Path
 from dotenv import load_dotenv
@@ -85,8 +87,80 @@ async def download_missing_illustrations(pool: Pool, base_dir: Path) -> None:
                 await fetch_image(record, session, pbar, illustration_dir)
 
 
-async def download_missing_images(pool: Pool) -> None:
+async def symbol_present(data: dict[str, Any], base_dir: Path) -> bool:
+    if not (identifier := data.get("id")):
+        return True
+
+    return await (base_dir / f"{identifier}.png").exists()
+
+
+async def filter_existence(data: dict[str, Any], base_dir: Path) -> dict[str, Any] | None:
+    if await symbol_present(data, base_dir):
+        return None
+
+    return data
+
+
+async def download_and_convert_symbol(
+    session: ClientSession, data: dict[str, Any] | None, base_dir: Path, pbar: tqdm
+) -> None:
+    if not data:
+        pbar.update()
+        return
+
+    identifier: str | None = data.get("id")
+    svg_url: str | None = data.get("icon_svg_uri")
+
+    if not identifier or not svg_url:
+        logger.warning(f"Could not find symbol for {identifier} / {svg_url}")
+        pbar.update()
+        return
+
+    try:
+        response = await session.get(svg_url)
+    except TimeoutError:
+        logger.warning(f"Timeout downloading symbol for {identifier}")
+        pbar.update()
+        return
+
+    if response.status != 200:
+        logger.warning(f"Could not download symbol for {identifier} ~ Status: {response.status}")
+        pbar.update()
+        return
+
+    try:
+        svg_bytes = await response.read()
+    except Exception:
+        logger.exception(f"Could not download symbol for {identifier} / {svg_url}")
+        pbar.update()
+        return
+
+    loop = asyncio.get_event_loop()
+    png_bytes = await loop.run_in_executor(
+        None, lambda: cairosvg.svg2png(bytestring=svg_bytes, output_width=256, output_height=256)
+    )
+    await (base_dir / f"{identifier}.png").write_bytes(png_bytes)
+    pbar.update()
+
+
+async def download_missing_set_symbols(base_dir: Path, set_data: list[dict[str, Any]]) -> None:
+    base_dir = base_dir / "sets"
+    with contextlib.suppress(FileExistsError):
+        await base_dir.mkdir(parents=True)
+
+    data = await asyncio.gather(*(filter_existence(data, base_dir) for data in set_data))
+    with tqdm(total=len(data)) as pbar:
+        pbar.set_description("Downloading symbols")
+        pbar.refresh()
+
+        connector = TCPConnector(limit=5)
+        async with ClientSession(connector=connector, timeout=ClientTimeout(total=300)) as session:
+            await asyncio.gather(*(download_and_convert_symbol(session, data, base_dir, pbar) for data in data))
+
+
+async def download_missing_images(pool: Pool, set_data: list[dict[str, Any]]) -> None:
     base_dir = Path(os.getenv("IMAGES_DIR"))
     await download_missing_card_images(pool, base_dir)
     await download_missing_illustrations(pool, base_dir)
+    await download_missing_set_symbols(base_dir, set_data)
     logger.info(f"Card images can be found: {await (await base_dir.resolve()).absolute()!s}")

--- a/uv.lock
+++ b/uv.lock
@@ -9,15 +9,6 @@ members = [
 ]
 
 [[package]]
-name = "aiofiles"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
-]
-
-[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -114,14 +105,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -219,7 +210,6 @@ name = "db-management"
 version = "0.1.0"
 source = { editable = "packages/db" }
 dependencies = [
-    { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "alembic" },
     { name = "anyio" },
@@ -233,9 +223,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "alembic", specifier = ">=1.16.4,<2.0.0" },
+    { name = "anyio", specifier = "==4.13.0" },
     { name = "anyio", specifier = ">=4.12.1,<5" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "greenlet", specifier = ">=3.3.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -149,6 +149,67 @@ wheels = [
 ]
 
 [[package]]
+name = "cairocffi"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/c5/1a4dc131459e68a173cbdab5fad6b524f53f9c1ef7861b7698e998b837cc/cairocffi-1.7.1.tar.gz", hash = "sha256:2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b", size = 88096, upload-time = "2024-06-18T10:56:06.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d8/ba13451aa6b745c49536e87b6bf8f629b950e84bd0e8308f7dc6883b67e2/cairocffi-1.7.1-py3-none-any.whl", hash = "sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f", size = 75611, upload-time = "2024-06-18T10:55:59.489Z" },
+]
+
+[[package]]
+name = "cairosvg"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cairocffi" },
+    { name = "cssselect2" },
+    { name = "defusedxml" },
+    { name = "pillow" },
+    { name = "tinycss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/07/e8412a13019b3f737972dea23a2c61ca42becafc16c9338f4ca7a0caa993/cairosvg-2.9.0.tar.gz", hash = "sha256:1debb00cd2da11350d8b6f5ceb739f1b539196d71d5cf5eb7363dbd1bfbc8dc5", size = 40877, upload-time = "2026-03-13T15:42:00.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5011747466414c12cac8a8df77aa235068669a6a5a5df301a96209db6054/cairosvg-2.9.0-py3-none-any.whl", hash = "sha256:4b82d07d145377dffdfc19d9791bd5fb65539bb4da0adecf0bdbd9cd4ffd7c68", size = 45962, upload-time = "2026-03-14T13:56:33.512Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -206,6 +267,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
+]
+
+[[package]]
 name = "db-management"
 version = "0.1.0"
 source = { editable = "packages/db" }
@@ -214,6 +288,7 @@ dependencies = [
     { name = "alembic" },
     { name = "anyio" },
     { name = "asyncpg" },
+    { name = "cairosvg" },
     { name = "greenlet" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -228,11 +303,21 @@ requires-dist = [
     { name = "anyio", specifier = "==4.13.0" },
     { name = "anyio", specifier = ">=4.12.1,<5" },
     { name = "asyncpg", specifier = ">=0.31.0" },
+    { name = "cairosvg", specifier = ">=2.7.0" },
     { name = "greenlet", specifier = ">=3.3.2" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "unidecode", specifier = ">=1.4.0" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -452,6 +537,39 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -522,6 +640,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -713,6 +840,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -767,6 +906,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  ## Summary
  - Downloads MTG set symbol SVGs from Scryfall and converts them to PNG (named by set code, e.g. `m10.png`)
  - Adds `sync_set_symbol_emojis()` which diffs local PNGs against existing Discord application emojis and uploads any missing ones, with rate-limit backoff and a guard against the 2000-emoji cap
  - Wires `APPLICATION_ID` into the CI/CD pipeline secret and the `card-insert` CronJob so the weekly sync job has Discord API access
  
  ## Test plan
  - [ ] Run the db-management script locally and confirm set symbol PNGs appear in `$IMAGES_DIR/sets/` named by set code
  - [ ] Confirm emojis appear on the Discord application after the script runs
  - [ ] Trigger a second run and confirm no duplicate uploads (idempotent)
  - [ ] Merge and verify the deploy pipeline applies the updated secret and k8s manifest cleanly
