### PR TITLE
Add AVX2 SIMD Jaro-Winkler to the fuzzy crate and wire the bot to it

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,3 +26,10 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+      # The deployed bot builds with fuzzy's `avx2` feature (see
+      # packages/bot/Dockerfile), which uses a different dispatch branch than
+      # the default build above. Exercise that path too. Safe here because
+      # GitHub's ubuntu-latest x86_64 runners support AVX2.
+      - name: Run tests (avx2 feature — deployed fuzzy code path)
+        run: cargo test -p fuzzy --features avx2

--- a/.run/Run Bot.run.xml
+++ b/.run/Run Bot.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Bot" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
     <option name="buildProfileId" value="dev" />
-    <option name="command" value="run -p rustcord --features local-dev" />
+    <option name="command" value="run -p rustcord --features local-dev,avx2" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
     <option name="emulateTerminal" value="true" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ name = "fuzzy"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "strsim",
 ]
 
 [[package]]

--- a/packages/bot/Cargo.toml
+++ b/packages/bot/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 
 [features]
 local-dev = ["dotenv"]
+# Opt into fuzzy's AVX2 kernel, skipping its per-call runtime CPU check.
+# Only build with this when the *deployment* CPU is known to expose AVX2 — a
+# binary built with it will execute an illegal instruction (SIGILL) on a CPU,
+# or VM (e.g. a Proxmox `kvm64` guest), that lacks AVX2. Build with
+# `cargo build --release -p rustcord --features avx2`.
+avx2 = ["fuzzy/avx2"]
 
 [dependencies]
 regex = "1.11.1"

--- a/packages/bot/Dockerfile
+++ b/packages/bot/Dockerfile
@@ -6,7 +6,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY packages ./packages
 
 RUN cargo fetch
-RUN cargo build --release -p rustcord
+RUN cargo build --release -p rustcord --features avx2
 
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/packages/bot/src/domain/functions/game/guess.rs
+++ b/packages/bot/src/domain/functions/game/guess.rs
@@ -38,7 +38,7 @@ where
         };
         game_state.add_guess();
 
-        if fuzzy::jaro_winkler_ascii_bitmask(
+        if fuzzy::jaro_winkler_ascii_simd(
             &normalise_card_name(&guess),
             &game_state.card().normalised_name(),
         ) > 0.75

--- a/packages/bot/src/domain/utils/card_picking.rs
+++ b/packages/bot/src/domain/utils/card_picking.rs
@@ -1,18 +1,23 @@
 use contracts::card::Card;
-use std::cmp::Ordering;
+use fuzzy::ToBytes;
+
+/// Local wrapper letting `Card` plug into `fuzzy::winkliest_sort`'s
+/// `ToBytes` bound without giving `contracts` a dependency on `fuzzy` (or
+/// vice versa) just for this one trait impl.
+struct CardByName(Card);
+
+impl ToBytes for CardByName {
+    fn to_bytes(&self) -> &[u8] {
+        self.0.normalised_name().as_bytes()
+    }
+}
 
 #[must_use]
 pub fn fuzzy_sort(needle: &str, haystack: Vec<Card>) -> Vec<Card> {
-    let mut scored: Vec<(f32, Card)> = haystack
+    fuzzy::winkliest_sort(&needle, haystack.into_iter().map(CardByName))
         .into_iter()
-        .map(|card| {
-            let score = fuzzy::jaro_winkler_ascii_bitmask(&needle, &card.normalised_name());
-            (score, card)
-        })
-        .collect();
-
-    scored.sort_by(|(x, _), (y, _)| y.partial_cmp(x).unwrap_or(Ordering::Equal));
-    scored.into_iter().map(|(_, card)| card).collect()
+        .map(|CardByName(card)| card)
+        .collect()
 }
 
 #[must_use]
@@ -73,6 +78,36 @@ mod tests {
             String::new(),
             time::Date::from_calendar_date(1993, time::Month::August, 5).unwrap(),
         )
+    }
+
+    #[test]
+    fn fuzzy_sort_orders_by_descending_similarity() {
+        // Pinning test: fuzzy_sort must order candidates by descending
+        // Jaro-Winkler similarity to the needle, regardless of internal
+        // implementation (hand-rolled scalar sort vs. fuzzy::winkliest_sort).
+        let bolt = make_card(
+            uuid!("00000000-0000-0000-0000-000000000001"),
+            "Lightning Bolt",
+            None,
+        );
+        let strike = make_card(
+            uuid!("00000000-0000-0000-0000-000000000002"),
+            "Lightning Strike",
+            None,
+        );
+        let chain = make_card(
+            uuid!("00000000-0000-0000-0000-000000000003"),
+            "Chain Lightning",
+            None,
+        );
+
+        let sorted = fuzzy_sort("lightning bolt", vec![chain, strike, bolt]);
+
+        let names: Vec<&str> = sorted.iter().map(Card::name).collect();
+        assert_eq!(
+            names,
+            vec!["Lightning Bolt", "Lightning Strike", "Chain Lightning"]
+        );
     }
 
     #[test]

--- a/packages/fuzzy/Cargo.toml
+++ b/packages/fuzzy/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 
 [dev-dependencies]
 criterion = "0.7"
+strsim = "0.11"
 
 [[bench]]
 name= "jw_bench"

--- a/packages/fuzzy/Cargo.toml
+++ b/packages/fuzzy/Cargo.toml
@@ -5,6 +5,14 @@ edition = "2024"
 
 [dependencies]
 
+[features]
+# Assume the target CPU supports AVX2 and skip the runtime
+# `is_x86_feature_detected!` check in favour of an unconditional call.
+# Only enable this when the deployment hardware is known to support AVX2 —
+# every x86_64 CPU from roughly the last decade does, but a binary built
+# with this feature will crash (illegal instruction) on one that doesn't.
+avx2 = []
+
 [dev-dependencies]
 criterion = "0.7"
 strsim = "0.11"

--- a/packages/fuzzy/benches/jw_bench.rs
+++ b/packages/fuzzy/benches/jw_bench.rs
@@ -30,6 +30,40 @@ fn bench(c: &mut Criterion) {
         });
         group.finish();
     }
+
+    // Batch functions over a realistic candidate list (normalised card names).
+    let target = "lightnig bolt";
+    let candidates = [
+        "lightning bolt",
+        "lightning strike",
+        "chain lightning",
+        "lightning helix",
+        "wall of lightning",
+        "lightning greaves",
+        "bolt of keranos",
+        "galvanic bolt",
+        "black lotus",
+        "the gitrog monster",
+        "gideon of the trials",
+        "okina temple to the grandfathers",
+        "counterspell",
+        "brainstorm",
+        "dark ritual",
+        "swords to plowshares",
+        "birds of paradise",
+        "llanowar elves",
+        "sol ring",
+        "force of will",
+    ];
+
+    let mut group = c.benchmark_group("winkliest");
+    group.bench_function("match", |b: &mut Bencher| {
+        b.iter(|| fuzzy::winkliest_match(&target, candidates))
+    });
+    group.bench_function("sort", |b: &mut Bencher| {
+        b.iter(|| fuzzy::winkliest_sort(&target, candidates))
+    });
+    group.finish();
 }
 
 criterion_group! {

--- a/packages/fuzzy/benches/jw_bench.rs
+++ b/packages/fuzzy/benches/jw_bench.rs
@@ -3,11 +3,25 @@ use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use fuzzy;
 
 fn bench(c: &mut Criterion) {
-    let sentence_1 = "some Long sentence";
-    let sentence_2 = "another long sentence";
+    let short_1 = "black lotus";
+    let short_2 = "black lotos";
 
-    c.bench_function("Bitmask JW", |b: &mut Bencher| {
-        b.iter(|| fuzzy::jaro_winkler_ascii_bitmask(&sentence_1, &sentence_2))
+    let typical_1 = "the gitrog monster";
+    let typical_2 = "the gitrog monstre";
+
+    let long_1 = "okina temple to the grandfathers okina temple grandfather";
+    let long_2 = "okina temple to the grandfathers okima temple grandfhater";
+
+    c.bench_function("Bitmask JW short (~11)", |b: &mut Bencher| {
+        b.iter(|| fuzzy::jaro_winkler_ascii_bitmask(&short_1, &short_2))
+    });
+
+    c.bench_function("Bitmask JW typical (~18)", |b: &mut Bencher| {
+        b.iter(|| fuzzy::jaro_winkler_ascii_bitmask(&typical_1, &typical_2))
+    });
+
+    c.bench_function("Bitmask JW long (~57)", |b: &mut Bencher| {
+        b.iter(|| fuzzy::jaro_winkler_ascii_bitmask(&long_1, &long_2))
     });
 }
 

--- a/packages/fuzzy/benches/jw_bench.rs
+++ b/packages/fuzzy/benches/jw_bench.rs
@@ -3,26 +3,33 @@ use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use fuzzy;
 
 fn bench(c: &mut Criterion) {
-    let short_1 = "black lotus";
-    let short_2 = "black lotos";
+    let cases = [
+        ("JW short (~11)", "black lotus", "black lotos"),
+        (
+            "JW typical (~18)",
+            "the gitrog monster",
+            "the gitrog monstre",
+        ),
+        (
+            "JW long (~57)",
+            "okina temple to the grandfathers okina temple grandfather",
+            "okina temple to the grandfathers okima temple grandfhater",
+        ),
+    ];
 
-    let typical_1 = "the gitrog monster";
-    let typical_2 = "the gitrog monstre";
-
-    let long_1 = "okina temple to the grandfathers okina temple grandfather";
-    let long_2 = "okina temple to the grandfathers okima temple grandfhater";
-
-    c.bench_function("Bitmask JW short (~11)", |b: &mut Bencher| {
-        b.iter(|| fuzzy::jaro_winkler_ascii_bitmask(&short_1, &short_2))
-    });
-
-    c.bench_function("Bitmask JW typical (~18)", |b: &mut Bencher| {
-        b.iter(|| fuzzy::jaro_winkler_ascii_bitmask(&typical_1, &typical_2))
-    });
-
-    c.bench_function("Bitmask JW long (~57)", |b: &mut Bencher| {
-        b.iter(|| fuzzy::jaro_winkler_ascii_bitmask(&long_1, &long_2))
-    });
+    for (name, s1, s2) in cases {
+        let mut group = c.benchmark_group(name);
+        group.bench_function("bitmask", |b: &mut Bencher| {
+            b.iter(|| fuzzy::jaro_winkler_ascii_bitmask(&s1, &s2))
+        });
+        group.bench_function("simd", |b: &mut Bencher| {
+            b.iter(|| fuzzy::jaro_winkler_ascii_simd(&s1, &s2))
+        });
+        group.bench_function("strsim", |b: &mut Bencher| {
+            b.iter(|| strsim::jaro_winkler(s1, s2))
+        });
+        group.finish();
+    }
 }
 
 criterion_group! {

--- a/packages/fuzzy/src/bmask.rs
+++ b/packages/fuzzy/src/bmask.rs
@@ -9,12 +9,7 @@ use crate::ToBytes;
 pub fn jaro_winkler_ascii_bitmask<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
     // The u64 match masks can only track 64 positions; longer inputs
     // degrade to a comparison of their first 64 bytes.
-    let a_bytes = a.to_bytes();
-    let b_bytes = b.to_bytes();
-    jaro_winkler_bytes(
-        &a_bytes[..a_bytes.len().min(64)],
-        &b_bytes[..b_bytes.len().min(64)],
-    )
+    jaro_winkler_bytes(crate::truncate_bytes64(a), crate::truncate_bytes64(b))
 }
 
 #[inline]

--- a/packages/fuzzy/src/bmask.rs
+++ b/packages/fuzzy/src/bmask.rs
@@ -1,0 +1,221 @@
+use crate::ToBytes;
+
+/// Scalar Jaro-Winkler over ASCII bytes (u64-bitmask implementation).
+///
+/// Kept public as the pure-scalar reference used by the benches and the
+/// SIMD equivalence tests. For the fastest available implementation, use
+/// [`crate::jaro_winkler_ascii_simd`] — it returns bit-identical scores.
+#[allow(clippy::cast_precision_loss)]
+pub fn jaro_winkler_ascii_bitmask<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
+    // The u64 match masks can only track 64 positions; longer inputs
+    // degrade to a comparison of their first 64 bytes.
+    let a_bytes = a.to_bytes();
+    let b_bytes = b.to_bytes();
+    jaro_winkler_bytes(
+        &a_bytes[..a_bytes.len().min(64)],
+        &b_bytes[..b_bytes.len().min(64)],
+    )
+}
+
+#[inline]
+#[allow(clippy::cast_precision_loss)]
+pub(crate) fn jaro_winkler_bytes(a_chars: &[u8], b_chars: &[u8]) -> f32 {
+    let len_a = a_chars.len();
+    let len_b = b_chars.len();
+
+    if a_chars == b_chars {
+        return 1.0;
+    }
+
+    let max_dist = (len_a.max(len_b) / 2).saturating_sub(1);
+    let mut matches: u32 = 0;
+    let mut hash_a: u64 = 0;
+    let mut hash_b: u64 = 0;
+
+    for (i, a_char) in a_chars.iter().enumerate() {
+        let end = (i + max_dist + 1).min(len_b);
+        let start = i.saturating_sub(max_dist).min(end);
+
+        for (j, b_char) in b_chars.iter().enumerate().take(end).skip(start) {
+            if (hash_b & (1 << j)) == 0 && a_char == b_char {
+                hash_a |= 1 << i;
+                hash_b |= 1 << j;
+                matches += 1;
+                break;
+            }
+        }
+    }
+
+    if matches == 0 {
+        return 0.0;
+    }
+
+    let mut transpositions: u32 = 0;
+    let mut b_matches = hash_b;
+
+    for (i, &a_char) in a_chars.iter().enumerate() {
+        if (hash_a & (1 << i)) != 0 {
+            let j = b_matches.trailing_zeros() as usize;
+            b_matches &= b_matches - 1;
+            if a_char != b_chars[j] {
+                transpositions += 1;
+            }
+        }
+    }
+
+    let matches = matches as f32;
+    let jaro_similarity = (1.0 / 3.0)
+        * (matches / len_a as f32
+            + matches / len_b as f32
+            + (matches - transpositions as f32 / 2.0) / matches);
+
+    let prefix_len = a_chars
+        .iter()
+        .zip(b_chars)
+        .take_while(|(c1, c2)| c1 == c2)
+        .count()
+        .min(4) as f32;
+
+    jaro_similarity + (prefix_len * 0.1 * (1.0 - jaro_similarity))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::jaro_winkler_ascii_bitmask;
+
+    #[test]
+    fn test_jaro_winkler_bitmask() {
+        let a = "CRATE";
+        let b = "TRACE";
+
+        let answer = jaro_winkler_ascii_bitmask(&a, &b);
+
+        assert_eq!(answer, 0.73333335)
+    }
+
+    #[test]
+    fn test_jaro_winkler_identical_strings() {
+        let a = "lightning bolt";
+        let b = "lightning bolt";
+
+        assert_eq!(jaro_winkler_ascii_bitmask(&a, &b), 1.0);
+    }
+
+    #[test]
+    fn test_jaro_winkler_empty_strings() {
+        let a = "";
+        let b = "";
+
+        assert_eq!(jaro_winkler_ascii_bitmask(&a, &b), 1.0);
+    }
+
+    #[test]
+    fn test_jaro_winkler_one_empty_string() {
+        let a = "card";
+        let b = "";
+
+        assert_eq!(jaro_winkler_ascii_bitmask(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn test_jaro_winkler_no_matches() {
+        let a = "abc";
+        let b = "xyz";
+
+        assert_eq!(jaro_winkler_ascii_bitmask(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn test_jaro_winkler_threshold_boundary() {
+        // Test around the 0.75 threshold used in the app
+        let a = "gitrog monster";
+        let b = "gitrog monstr";
+
+        let score = jaro_winkler_ascii_bitmask(&a, &b);
+        assert!(score > 0.75, "Expected score > 0.75, got {}", score);
+    }
+
+    #[test]
+    fn test_jaro_winkler_case_sensitive() {
+        // The algorithm is case-sensitive (normalization happens elsewhere)
+        let a = "Lightning Bolt";
+        let b = "lightning bolt";
+
+        let score = jaro_winkler_ascii_bitmask(&a, &b);
+        assert!(score < 1.0, "Should be case-sensitive");
+    }
+
+    #[test]
+    fn test_jaro_winkler_long_strings() {
+        let a = "the gitrog monster is a legendary frog horror creature";
+        let b = "the gitrog monster is a legendary frog horor creature";
+
+        let score = jaro_winkler_ascii_bitmask(&a, &b);
+        assert!(score > 0.9, "Should handle long strings with minor typos");
+    }
+
+    #[test]
+    fn test_jaro_winkler_single_char() {
+        let a = "a";
+        let b = "b";
+
+        assert_eq!(jaro_winkler_ascii_bitmask(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn test_jaro_winkler_single_char_match() {
+        let a = "x";
+        let b = "x";
+
+        assert_eq!(jaro_winkler_ascii_bitmask(&a, &b), 1.0);
+    }
+
+    #[test]
+    fn test_jaro_winkler_prefix_boost() {
+        // Strings with common prefix should score higher than those without
+        let a = "lightning bolt";
+        let with_prefix = "lightning strike";
+        let without_prefix = "chain lightning";
+
+        let score_with = jaro_winkler_ascii_bitmask(&a, &with_prefix);
+        let score_without = jaro_winkler_ascii_bitmask(&a, &without_prefix);
+
+        assert!(
+            score_with > score_without,
+            "Common prefix should boost score: {} vs {}",
+            score_with,
+            score_without
+        );
+    }
+
+    #[test]
+    fn test_jaro_winkler_transposition() {
+        let a = "martha";
+        let b = "marhta";
+
+        let score = jaro_winkler_ascii_bitmask(&a, &b);
+        assert!(score > 0.9, "Transpositions should still score high");
+    }
+
+    #[test]
+    fn test_jaro_winkler_over_64_bytes_truncates() {
+        // Inputs longer than 64 bytes are truncated to their first 64 bytes,
+        // so strings identical up to byte 64 score as an exact match.
+        let a = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg1234567890";
+        let b = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg0987654321";
+        assert_eq!(a.len(), 74);
+        assert_eq!(b.len(), 74);
+
+        assert_eq!(jaro_winkler_ascii_bitmask(&a, &b), 1.0);
+    }
+
+    #[test]
+    fn test_jaro_winkler_unicode_safe() {
+        // Should handle UTF-8 safely (even if not ideal for non-ASCII)
+        let a = "café";
+        let b = "cafe";
+
+        let score = jaro_winkler_ascii_bitmask(&a, &b);
+        assert!(score > 0.0);
+    }
+}

--- a/packages/fuzzy/src/lib.rs
+++ b/packages/fuzzy/src/lib.rs
@@ -1,3 +1,43 @@
+//! Fast Jaro-Winkler string similarity over ASCII bytes.
+//!
+//! This crate scores similarity between short, already-normalised strings —
+//! card names, set names, artist names — for fuzzy search and guess matching.
+//! It is not a general-purpose Unicode similarity library; see the assumptions
+//! below.
+//!
+//! # Input assumptions
+//!
+//! - **Pre-normalised ASCII.** Scoring compares bytes, so it is case- and
+//!   accent-sensitive. Callers are expected to have lower-cased and stripped
+//!   diacritics beforehand (`"Café"` and `"cafe"` do *not* score as equal).
+//! - **First 64 bytes only.** Every entry point truncates each input to its
+//!   first 64 bytes before scoring — the algorithm tracks match positions in a
+//!   `u64` bitmask. Strings that are identical up to byte 64 score as an exact
+//!   match. This is ample for the card/set/artist names this crate targets.
+//!
+//! # Public API
+//!
+//! - [`jaro_winkler_ascii_simd`] — the fast path; dispatches to an AVX2 kernel
+//!   when available and falls back to the scalar implementation otherwise.
+//!   Prefer this for scoring a single pair.
+//! - [`jaro_winkler_ascii_bitmask`] — the pure scalar reference. Returns
+//!   scores bit-identical to the SIMD path; kept public for benches and tests.
+//! - [`winkliest_match`] / [`winkliest_sort`] — pick the closest candidate, or
+//!   order a set of candidates, against one target. Both use the same
+//!   accelerated dispatch.
+//! - [`ToBytes`] — the trait inputs implement to expose their bytes. Provided
+//!   for `&str` and `String`; implement it on a newtype to score other types.
+//!
+//! # The `avx2` feature
+//!
+//! By default the SIMD path performs a (cached) runtime `is_x86_feature_detected!`
+//! check per process and stays portable across `x86_64` CPUs. Enabling the
+//! `avx2` feature **asserts** AVX2 is present and skips that check, calling the
+//! AVX2 kernel unconditionally. Only enable it when the deployment CPU is known
+//! to support AVX2 — a binary built with the feature will execute an illegal
+//! instruction on a CPU without it. The feature is rejected at compile time on
+//! non-`x86_64` targets.
+
 use std::cmp::Ordering;
 
 mod bmask;
@@ -51,25 +91,25 @@ pub(crate) unsafe fn jaro_winkler_unchecked(a: &[u8], b: &[u8]) -> f32 {
 /// Return the candidate from `heap` with the highest Jaro-Winkler similarity
 /// to `target`, or `None` if `heap` is empty.
 ///
-/// Scoring uses the same accelerated dispatch as [`jaro_winkler_ascii_simd`].
+/// If several candidates tie for the highest score, the last one in iteration
+/// order is returned. Scoring uses the same accelerated dispatch as
+/// [`jaro_winkler_ascii_simd`].
+#[must_use]
 pub fn winkliest_match<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
     target: &A,
     heap: I,
 ) -> Option<B> {
-    let target_bytes_checked = {
-        let target_bytes = target.to_bytes();
-        &target_bytes[..target_bytes.len().min(64)]
-    };
+    let target_bytes_checked = truncate_bytes64(target);
     let (_, closest_match) = heap
         .into_iter()
         .map(|needle| {
-            let needle_bytes_checked = {
-                let needle_bytes = needle.to_bytes();
-                &needle_bytes[..needle_bytes.len().min(64)]
-            };
+            let needle_bytes_checked = truncate_bytes64(&needle);
 
             // SAFETY: truncated to <= 64 bytes above.
-            (unsafe { jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked) }, needle)
+            (
+                unsafe { jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked) },
+                needle,
+            )
         })
         .max_by(|&(x, _), (y, _)| x.partial_cmp(y).unwrap_or(Ordering::Less))?;
 
@@ -80,21 +120,16 @@ pub fn winkliest_match<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
 ///
 /// The relative order of equal-scored candidates is unspecified.
 /// Scoring uses the same accelerated dispatch as [`jaro_winkler_ascii_simd`].
+#[must_use]
 pub fn winkliest_sort<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
     target: &A,
     heap: I,
 ) -> Vec<B> {
-    let target_bytes_checked = {
-        let target_bytes = target.to_bytes();
-        &target_bytes[..target_bytes.len().min(64)]
-    };
+    let target_bytes_checked = truncate_bytes64(target);
     let mut scored: Vec<_> = heap
         .into_iter()
         .map(|needle| {
-            let needle_bytes_checked = {
-                let needle_bytes = needle.to_bytes();
-                &needle_bytes[..needle_bytes.len().min(64)]
-            };
+            let needle_bytes_checked = truncate_bytes64(&needle);
 
             (
                 // SAFETY: truncated to <= 64 bytes above.
@@ -104,13 +139,41 @@ pub fn winkliest_sort<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
         })
         .collect();
 
-    scored.sort_unstable_by(|(x, _), (y, _)| y.partial_cmp(x).unwrap_or(Ordering::Equal));
+    scored.sort_unstable_by(|(x, _), (y, _)| y.partial_cmp(x).unwrap_or(Ordering::Less));
     scored.into_iter().map(|(_, item)| item).collect()
+}
+
+/// Truncate a value's bytes to the first 64 (the length the kernels can score).
+#[must_use]
+#[inline]
+pub(crate) fn truncate_bytes64(target: &impl ToBytes) -> &[u8] {
+    truncate64(target.to_bytes())
+}
+
+/// Truncate a byte slice to its first 64 bytes.
+#[must_use]
+#[inline]
+pub(crate) fn truncate64(target: &[u8]) -> &[u8] {
+    &target[..target.len().min(64)]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn jaro_winkler_unchecked_debug_asserts_length_contract() {
+        // The unsafe contract (each slice <= 64 bytes) is guarded by a
+        // debug_assert that fires before any unchecked access. Callers only
+        // reach the kernel through `truncate_bytes64`, so this cannot happen in
+        // practice — this test is the tripwire if that guard ever regresses.
+        let over = [b'a'; 65];
+        // SAFETY: intentionally violating the length precondition to prove the
+        // debug_assert catches it; in a debug (test) build the assert panics
+        // before the kernel performs any unsafe read.
+        let _ = unsafe { jaro_winkler_unchecked(&over, &over) };
+    }
 
     #[test]
     fn test_jaro_winkler_bitmask() {
@@ -277,12 +340,26 @@ mod tests {
 
     #[test]
     fn test_winkliest_match_tie_breaker() {
-        // When scores are equal, should return first max found
+        // Two candidates that score identically against the target: each is
+        // "test" plus one trailing digit that matches nothing in "test", so
+        // the scores tie. `max_by` returns the last equal-max element, so the
+        // later candidate in iteration order must win.
         let target = "test";
-        let candidates = ["test1", "test2"];
+        let first = "test1";
+        let last = "test2";
 
-        let result = winkliest_match(&target, candidates);
-        assert!(result.is_some());
+        // Premise: the two candidates really do tie.
+        assert_eq!(
+            jaro_winkler_ascii_simd(&target, &first),
+            jaro_winkler_ascii_simd(&target, &last),
+            "candidates must tie for this to exercise tie-breaking",
+        );
+
+        // The last equal-max candidate wins...
+        assert_eq!(winkliest_match(&target, [first, last]), Some(last));
+        // ...and swapping the order flips which one wins, confirming the
+        // choice is by iteration order, not by value.
+        assert_eq!(winkliest_match(&target, [last, first]), Some(first));
     }
 
     #[test]

--- a/packages/fuzzy/src/lib.rs
+++ b/packages/fuzzy/src/lib.rs
@@ -20,6 +20,11 @@ impl ToBytes for String {
     }
 }
 
+/// Scalar Jaro-Winkler over ASCII bytes (u64-bitmask implementation).
+///
+/// Kept public as the pure-scalar reference used by the benches and the
+/// SIMD equivalence tests. For the fastest available implementation, use
+/// [`jaro_winkler_ascii_simd`] — it returns bit-identical scores.
 #[allow(clippy::cast_precision_loss)]
 pub fn jaro_winkler_ascii_bitmask<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
     // The u64 match masks can only track 64 positions; longer inputs
@@ -95,14 +100,19 @@ pub(crate) fn jaro_winkler_bytes(a_chars: &[u8], b_chars: &[u8]) -> f32 {
     jaro_similarity + (prefix_len * scaling_factor * (1.0 - jaro_similarity))
 }
 
-pub fn winkliest_match<A: ToBytes, B: ToBytes, I: AsRef<[B]> + IntoIterator<Item = B>>(
+/// Return the candidate from `heap` with the highest Jaro-Winkler similarity
+/// to `target`, or `None` if `heap` is empty.
+///
+/// Scoring uses the same accelerated dispatch as [`jaro_winkler_ascii_simd`].
+pub fn winkliest_match<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
     target: &A,
     heap: I,
 ) -> Option<B> {
+    let target_bytes = target.to_bytes();
     let (_, closest_match) = heap
         .into_iter()
         .map(|needle| {
-            let distance = jaro_winkler_ascii_bitmask(target, &needle);
+            let distance = simd::jaro_winkler_slices(target_bytes, needle.to_bytes());
             (distance, needle)
         })
         .max_by(|&(x, _), (y, _)| x.partial_cmp(y).unwrap_or(Ordering::Less))?;
@@ -110,16 +120,26 @@ pub fn winkliest_match<A: ToBytes, B: ToBytes, I: AsRef<[B]> + IntoIterator<Item
     Some(closest_match)
 }
 
+/// Sort candidates by descending Jaro-Winkler similarity to `target`.
+///
+/// The relative order of equal-scored candidates is unspecified.
+/// Scoring uses the same accelerated dispatch as [`jaro_winkler_ascii_simd`].
 pub fn winkliest_sort<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
     target: &A,
     heap: I,
 ) -> Vec<B> {
+    let target_bytes = target.to_bytes();
     let mut scored: Vec<_> = heap
         .into_iter()
-        .map(|needle| (jaro_winkler_ascii_bitmask(target, &needle), needle))
+        .map(|needle| {
+            (
+                simd::jaro_winkler_slices(target_bytes, needle.to_bytes()),
+                needle,
+            )
+        })
         .collect();
 
-    scored.sort_by(|(x, _), (y, _)| y.partial_cmp(x).unwrap_or(Ordering::Equal));
+    scored.sort_unstable_by(|(x, _), (y, _)| y.partial_cmp(x).unwrap_or(Ordering::Equal));
     scored.into_iter().map(|(_, item)| item).collect()
 }
 
@@ -356,6 +376,18 @@ mod tests {
     }
 
     #[test]
+    fn test_winkliest_match_accepts_plain_iterator() {
+        // Iterator adapters (here: filter) implement IntoIterator but not
+        // AsRef<[&str]>, so this only compiles once the dead bound is gone.
+        let a = "CRATE";
+        let candidates = ["TRACE", "zzz", "sdasda"];
+
+        let result = winkliest_match(&a, candidates.into_iter().filter(|s| s.len() > 3));
+
+        assert_eq!(result, Some("TRACE"));
+    }
+
+    #[test]
     fn test_jaro_winkler_unicode_safe() {
         // Should handle UTF-8 safely (even if not ideal for non-ASCII)
         let a = "café";
@@ -363,5 +395,31 @@ mod tests {
 
         let score = jaro_winkler_ascii_bitmask(&a, &b);
         assert!(score > 0.0);
+    }
+
+    #[test]
+    fn test_winkliest_sort_order_matches_bitmask_scores() {
+        // Pinning test: winkliest_sort's ordering must always agree with
+        // sorting by jaro_winkler_ascii_bitmask scores directly. Candidates
+        // are chosen with strictly distinct scores so the assertion is
+        // insensitive to tie-ordering.
+        let target = "lightning bolt";
+        let candidates = [
+            "chain lightning",
+            "lightning strike",
+            "lightning bolt",
+            "bolt",
+        ];
+
+        let sorted = winkliest_sort(&target, candidates);
+
+        let mut expected: Vec<(f32, &str)> = candidates
+            .iter()
+            .map(|c| (jaro_winkler_ascii_bitmask(&target, c), *c))
+            .collect();
+        expected.sort_by(|(x, _), (y, _)| y.partial_cmp(x).unwrap_or(Ordering::Equal));
+        let expected: Vec<&str> = expected.into_iter().map(|(_, c)| c).collect();
+
+        assert_eq!(sorted, expected);
     }
 }

--- a/packages/fuzzy/src/lib.rs
+++ b/packages/fuzzy/src/lib.rs
@@ -1,5 +1,9 @@
 use std::cmp::Ordering;
 
+mod simd;
+
+pub use simd::jaro_winkler_ascii_simd;
+
 pub trait ToBytes {
     fn to_bytes(&self) -> &[u8];
 }
@@ -22,8 +26,15 @@ pub fn jaro_winkler_ascii_bitmask<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
     // degrade to a comparison of their first 64 bytes.
     let a_bytes = a.to_bytes();
     let b_bytes = b.to_bytes();
-    let a_chars = &a_bytes[..a_bytes.len().min(64)];
-    let b_chars = &b_bytes[..b_bytes.len().min(64)];
+    jaro_winkler_bytes(
+        &a_bytes[..a_bytes.len().min(64)],
+        &b_bytes[..b_bytes.len().min(64)],
+    )
+}
+
+#[inline]
+#[allow(clippy::cast_precision_loss)]
+pub(crate) fn jaro_winkler_bytes(a_chars: &[u8], b_chars: &[u8]) -> f32 {
     let len_a = a_chars.len();
     let len_b = b_chars.len();
 

--- a/packages/fuzzy/src/lib.rs
+++ b/packages/fuzzy/src/lib.rs
@@ -95,9 +95,8 @@ pub(crate) fn jaro_winkler_bytes(a_chars: &[u8], b_chars: &[u8]) -> f32 {
         .take_while(|(c1, c2)| c1 == c2)
         .count()
         .min(4) as f32;
-    let scaling_factor = 0.1;
 
-    jaro_similarity + (prefix_len * scaling_factor * (1.0 - jaro_similarity))
+    jaro_similarity + (prefix_len * 0.1 * (1.0 - jaro_similarity))
 }
 
 /// Return the candidate from `heap` with the highest Jaro-Winkler similarity
@@ -108,11 +107,21 @@ pub fn winkliest_match<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
     target: &A,
     heap: I,
 ) -> Option<B> {
-    let target_bytes = target.to_bytes();
+    let target_bytes_checked = {
+        let target_bytes = target.to_bytes();
+        &target_bytes[..target_bytes.len().min(64)]
+    };
     let (_, closest_match) = heap
         .into_iter()
         .map(|needle| {
-            let distance = simd::jaro_winkler_slices(target_bytes, needle.to_bytes());
+            let needle_bytes_checked = {
+                let needle_bytes = needle.to_bytes();
+                &needle_bytes[..needle_bytes.len().min(64)]
+            };
+
+            let distance = unsafe {
+                simd::jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked)
+            };
             (distance, needle)
         })
         .max_by(|&(x, _), (y, _)| x.partial_cmp(y).unwrap_or(Ordering::Less))?;
@@ -128,12 +137,20 @@ pub fn winkliest_sort<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
     target: &A,
     heap: I,
 ) -> Vec<B> {
-    let target_bytes = target.to_bytes();
+    let target_bytes_checked = {
+        let target_bytes = target.to_bytes();
+        &target_bytes[..target_bytes.len().min(64)]
+    };
     let mut scored: Vec<_> = heap
         .into_iter()
         .map(|needle| {
+            let needle_bytes_checked = {
+                let needle_bytes = needle.to_bytes();
+                &needle_bytes[..needle_bytes.len().min(64)]
+            };
+
             (
-                simd::jaro_winkler_slices(target_bytes, needle.to_bytes()),
+                unsafe { simd::jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked) },
                 needle,
             )
         })

--- a/packages/fuzzy/src/lib.rs
+++ b/packages/fuzzy/src/lib.rs
@@ -17,80 +17,74 @@ impl ToBytes for String {
 }
 
 #[allow(clippy::cast_precision_loss)]
-pub fn jaro_winkler_ascii_bitmask<A: ToBytes + PartialEq<B>, B: ToBytes>(a: &A, b: &B) -> f32 {
-    let a_chars = a.to_bytes();
-    let b_chars = b.to_bytes();
+pub fn jaro_winkler_ascii_bitmask<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
+    // The u64 match masks can only track 64 positions; longer inputs
+    // degrade to a comparison of their first 64 bytes.
+    let a_bytes = a.to_bytes();
+    let b_bytes = b.to_bytes();
+    let a_chars = &a_bytes[..a_bytes.len().min(64)];
+    let b_chars = &b_bytes[..b_bytes.len().min(64)];
     let len_a = a_chars.len();
     let len_b = b_chars.len();
 
-    if a == b {
+    if a_chars == b_chars {
         return 1.0;
     }
 
     let max_dist = (len_a.max(len_b) / 2).saturating_sub(1);
-    let mut matches = 0.0;
+    let mut matches: u32 = 0;
     let mut hash_a: u64 = 0;
     let mut hash_b: u64 = 0;
 
-    for (i, a_char) in a_chars.iter().enumerate().take(len_a) {
-        let start = i.saturating_sub(max_dist);
+    for (i, a_char) in a_chars.iter().enumerate() {
         let end = (i + max_dist + 1).min(len_b);
+        let start = i.saturating_sub(max_dist).min(end);
 
         for (j, b_char) in b_chars.iter().enumerate().take(end).skip(start) {
             if (hash_b & (1 << j)) == 0 && a_char == b_char {
                 hash_a |= 1 << i;
                 hash_b |= 1 << j;
-                matches += 1.0;
+                matches += 1;
                 break;
             }
         }
     }
 
-    if matches == 0.0 {
+    if matches == 0 {
         return 0.0;
     }
 
-    let mut transpositions = 0.0;
-    let mut b_ptr = 0;
+    let mut transpositions: u32 = 0;
+    let mut b_matches = hash_b;
 
-    for (i, &a_char) in a_chars.iter().enumerate().take(len_a) {
+    for (i, &a_char) in a_chars.iter().enumerate() {
         if (hash_a & (1 << i)) != 0 {
-            while (hash_b & (1 << b_ptr)) == 0 {
-                b_ptr += 1;
+            let j = b_matches.trailing_zeros() as usize;
+            b_matches &= b_matches - 1;
+            if a_char != b_chars[j] {
+                transpositions += 1;
             }
-            if a_char != b_chars[b_ptr] {
-                transpositions += 1.0;
-            }
-            b_ptr += 1;
         }
     }
 
+    let matches = matches as f32;
     let jaro_similarity = (1.0 / 3.0)
         * (matches / len_a as f32
             + matches / len_b as f32
-            + (matches - transpositions / 2.0) / matches);
+            + (matches - transpositions as f32 / 2.0) / matches);
 
-    let mut prefix_len = 0;
-    for (c1, c2) in a_chars.iter().zip(b_chars) {
-        if c1 == c2 {
-            prefix_len += 1;
-        } else {
-            break;
-        }
-    }
-
-    #[allow(clippy::cast_sign_loss)]
-    let prefix_len = (prefix_len as usize).min(4) as f32;
+    let prefix_len = a_chars
+        .iter()
+        .zip(b_chars)
+        .take_while(|(c1, c2)| c1 == c2)
+        .count()
+        .min(4) as f32;
     let scaling_factor = 0.1;
 
     jaro_similarity + (prefix_len * scaling_factor * (1.0 - jaro_similarity))
 }
 
-pub fn winkliest_match<
-    A: PartialEq<B> + ToBytes,
-    B: ToBytes,
-    I: AsRef<[B]> + IntoIterator<Item = B>,
->(
+pub fn winkliest_match<A: ToBytes, B: ToBytes, I: AsRef<[B]> + IntoIterator<Item = B>>(
     target: &A,
     heap: I,
 ) -> Option<B> {
@@ -105,7 +99,7 @@ pub fn winkliest_match<
     Some(closest_match)
 }
 
-pub fn winkliest_sort<A: PartialEq<B> + ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
+pub fn winkliest_sort<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
     target: &A,
     heap: I,
 ) -> Vec<B> {
@@ -336,6 +330,18 @@ mod tests {
     fn test_to_bytes_trait_str() {
         let s = "test";
         assert_eq!(s.to_bytes(), b"test");
+    }
+
+    #[test]
+    fn test_jaro_winkler_over_64_bytes_truncates() {
+        // Inputs longer than 64 bytes are truncated to their first 64 bytes,
+        // so strings identical up to byte 64 score as an exact match.
+        let a = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg1234567890";
+        let b = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg0987654321";
+        assert_eq!(a.len(), 74);
+        assert_eq!(b.len(), 74);
+
+        assert_eq!(jaro_winkler_ascii_bitmask(&a, &b), 1.0);
     }
 
     #[test]

--- a/packages/fuzzy/src/lib.rs
+++ b/packages/fuzzy/src/lib.rs
@@ -1,7 +1,9 @@
 use std::cmp::Ordering;
 
+mod bmask;
 mod simd;
 
+pub use bmask::jaro_winkler_ascii_bitmask;
 pub use simd::jaro_winkler_ascii_simd;
 
 pub trait ToBytes {
@@ -20,83 +22,30 @@ impl ToBytes for String {
     }
 }
 
-/// Scalar Jaro-Winkler over ASCII bytes (u64-bitmask implementation).
+/// AVX2/scalar dispatch, skipping the length truncation `jaro_winkler_ascii_simd` does.
 ///
-/// Kept public as the pure-scalar reference used by the benches and the
-/// SIMD equivalence tests. For the fastest available implementation, use
-/// [`jaro_winkler_ascii_simd`] — it returns bit-identical scores.
-#[allow(clippy::cast_precision_loss)]
-pub fn jaro_winkler_ascii_bitmask<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
-    // The u64 match masks can only track 64 positions; longer inputs
-    // degrade to a comparison of their first 64 bytes.
-    let a_bytes = a.to_bytes();
-    let b_bytes = b.to_bytes();
-    jaro_winkler_bytes(
-        &a_bytes[..a_bytes.len().min(64)],
-        &b_bytes[..b_bytes.len().min(64)],
-    )
-}
-
+/// # Safety
+/// `a` and `b` must each be at most 64 bytes. Violating this panics on the
+/// AVX2 path (bounds-checked buffer copy), but on the scalar fallback in a
+/// release build it silently returns a wrong score instead of panicking —
+/// the match-bit shift (`1 << i`) overflows a `u64` and wraps once
+/// overflow checks are off.
 #[inline]
-#[allow(clippy::cast_precision_loss)]
-pub(crate) fn jaro_winkler_bytes(a_chars: &[u8], b_chars: &[u8]) -> f32 {
-    let len_a = a_chars.len();
-    let len_b = b_chars.len();
+pub(crate) unsafe fn jaro_winkler_unchecked(a: &[u8], b: &[u8]) -> f32 {
+    debug_assert!(a.len() <= 64 && b.len() <= 64);
 
-    if a_chars == b_chars {
-        return 1.0;
+    #[cfg(all(not(feature = "avx2"), target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx2") {
+        // SAFETY: AVX2 availability just checked; caller guarantees length <= 64.
+        return unsafe { simd::avx2::jaro_winkler(a, b) };
     }
 
-    let max_dist = (len_a.max(len_b) / 2).saturating_sub(1);
-    let mut matches: u32 = 0;
-    let mut hash_a: u64 = 0;
-    let mut hash_b: u64 = 0;
+    #[cfg(feature = "avx2")]
+    // SAFETY: the `avx2` feature asserts AVX2 is available; caller guarantees length <= 64.
+    return unsafe { simd::avx2::jaro_winkler(a, b) };
 
-    for (i, a_char) in a_chars.iter().enumerate() {
-        let end = (i + max_dist + 1).min(len_b);
-        let start = i.saturating_sub(max_dist).min(end);
-
-        for (j, b_char) in b_chars.iter().enumerate().take(end).skip(start) {
-            if (hash_b & (1 << j)) == 0 && a_char == b_char {
-                hash_a |= 1 << i;
-                hash_b |= 1 << j;
-                matches += 1;
-                break;
-            }
-        }
-    }
-
-    if matches == 0 {
-        return 0.0;
-    }
-
-    let mut transpositions: u32 = 0;
-    let mut b_matches = hash_b;
-
-    for (i, &a_char) in a_chars.iter().enumerate() {
-        if (hash_a & (1 << i)) != 0 {
-            let j = b_matches.trailing_zeros() as usize;
-            b_matches &= b_matches - 1;
-            if a_char != b_chars[j] {
-                transpositions += 1;
-            }
-        }
-    }
-
-    let matches = matches as f32;
-    let jaro_similarity = (1.0 / 3.0)
-        * (matches / len_a as f32
-            + matches / len_b as f32
-            + (matches - transpositions as f32 / 2.0) / matches);
-
-    let prefix_len = a_chars
-        .iter()
-        .zip(b_chars)
-        .take_while(|(c1, c2)| c1 == c2)
-        .count()
-        .min(4) as f32;
-
-    jaro_similarity + (prefix_len * 0.1 * (1.0 - jaro_similarity))
+    #[cfg(not(feature = "avx2"))]
+    bmask::jaro_winkler_bytes(a, b)
 }
 
 /// Return the candidate from `heap` with the highest Jaro-Winkler similarity
@@ -119,9 +68,8 @@ pub fn winkliest_match<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
                 &needle_bytes[..needle_bytes.len().min(64)]
             };
 
-            let distance = unsafe {
-                simd::jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked)
-            };
+            let distance =
+                unsafe { jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked) };
             (distance, needle)
         })
         .max_by(|&(x, _), (y, _)| x.partial_cmp(y).unwrap_or(Ordering::Less))?;
@@ -150,7 +98,7 @@ pub fn winkliest_sort<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
             };
 
             (
-                unsafe { simd::jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked) },
+                unsafe { jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked) },
                 needle,
             )
         })

--- a/packages/fuzzy/src/lib.rs
+++ b/packages/fuzzy/src/lib.rs
@@ -68,9 +68,8 @@ pub fn winkliest_match<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
                 &needle_bytes[..needle_bytes.len().min(64)]
             };
 
-            let distance =
-                unsafe { jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked) };
-            (distance, needle)
+            // SAFETY: truncated to <= 64 bytes above.
+            (unsafe { jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked) }, needle)
         })
         .max_by(|&(x, _), (y, _)| x.partial_cmp(y).unwrap_or(Ordering::Less))?;
 
@@ -98,6 +97,7 @@ pub fn winkliest_sort<A: ToBytes, B: ToBytes, I: IntoIterator<Item = B>>(
             };
 
             (
+                // SAFETY: truncated to <= 64 bytes above.
                 unsafe { jaro_winkler_unchecked(target_bytes_checked, needle_bytes_checked) },
                 needle,
             )

--- a/packages/fuzzy/src/simd.rs
+++ b/packages/fuzzy/src/simd.rs
@@ -137,10 +137,15 @@ pub(crate) mod avx2 {
 /// longer than 64 bytes are truncated to their first 64 bytes.
 #[must_use]
 pub fn jaro_winkler_ascii_simd<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
-    let a_bytes = a.to_bytes();
-    let b_bytes = b.to_bytes();
-    let a_chars = &a_bytes[..a_bytes.len().min(64)];
-    let b_chars = &b_bytes[..b_bytes.len().min(64)];
+    jaro_winkler_slices(a.to_bytes(), b.to_bytes())
+}
+
+/// Slice-level entry point for the same dispatch: safe for slices of any
+/// length (truncates to 64 bytes internally before the kernel).
+#[must_use]
+pub(crate) fn jaro_winkler_slices(a: &[u8], b: &[u8]) -> f32 {
+    let a_chars = &a[..a.len().min(64)];
+    let b_chars = &b[..b.len().min(64)];
 
     #[cfg(target_arch = "x86_64")]
     if is_x86_feature_detected!("avx2") {

--- a/packages/fuzzy/src/simd.rs
+++ b/packages/fuzzy/src/simd.rs
@@ -36,6 +36,7 @@ pub(crate) mod avx2 {
     /// The caller must ensure the CPU supports AVX2 and that both slices are
     /// at most 64 bytes long.
     #[target_feature(enable = "avx2")]
+    #[inline]
     #[allow(clippy::cast_precision_loss, clippy::cast_possible_wrap)]
     pub(crate) unsafe fn jaro_winkler(a: &[u8], b: &[u8]) -> f32 {
         debug_assert!(a.len() <= 64 && b.len() <= 64);
@@ -139,15 +140,8 @@ pub(crate) mod avx2 {
 /// longer than 64 bytes are truncated to their first 64 bytes.
 #[must_use]
 pub fn jaro_winkler_ascii_simd<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
-    let a_bytes = {
-        let bytes = a.to_bytes();
-        &bytes[..bytes.len().min(64)]
-    };
-
-    let b_bytes = {
-        let bytes = b.to_bytes();
-        &bytes[..bytes.len().min(64)]
-    };
+    let a_bytes = crate::truncate_bytes64(a);
+    let b_bytes = crate::truncate_bytes64(b);
 
     // SAFETY: truncated to <= 64 bytes above.
     unsafe { crate::jaro_winkler_unchecked(a_bytes, b_bytes) }

--- a/packages/fuzzy/src/simd.rs
+++ b/packages/fuzzy/src/simd.rs
@@ -30,7 +30,7 @@ pub(crate) mod avx2 {
     }
 
     /// AVX2 Jaro-Winkler over byte slices. Bit-identical to
-    /// [`crate::jaro_winkler_bytes`].
+    /// [`crate::bmask::jaro_winkler_bytes`].
     ///
     /// # Safety
     /// The caller must ensure the CPU supports AVX2 and that both slices are
@@ -139,49 +139,18 @@ pub(crate) mod avx2 {
 /// longer than 64 bytes are truncated to their first 64 bytes.
 #[must_use]
 pub fn jaro_winkler_ascii_simd<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
-    jaro_winkler_slices(a.to_bytes(), b.to_bytes())
-}
+    let a_bytes = {
+        let bytes = a.to_bytes();
+        &bytes[..bytes.len().min(64)]
+    };
 
-/// Slice-level entry point for the same dispatch: safe for slices of any
-/// length (truncates to 64 bytes internally before the kernel).
-///
-/// With the `avx2` feature enabled, the runtime `is_x86_feature_detected!`
-/// check is skipped and the AVX2 kernel is called unconditionally — only
-/// enable that feature when the deployment CPU is known to support AVX2
-/// (see `fuzzy/Cargo.toml`).
-#[must_use]
-#[inline]
-pub(crate) fn jaro_winkler_slices(a: &[u8], b: &[u8]) -> f32 {
-    let a_chars = &a[..a.len().min(64)];
-    let b_chars = &b[..b.len().min(64)];
+    let b_bytes = {
+        let bytes = b.to_bytes();
+        &bytes[..bytes.len().min(64)]
+    };
+
     // SAFETY: truncated to <= 64 bytes above.
-    unsafe { jaro_winkler_unchecked(a_chars, b_chars) }
-}
-
-/// AVX2/scalar dispatch, skipping the length truncation `jaro_winkler_slices` does.
-///
-/// # Safety
-/// `a` and `b` must each be at most 64 bytes. Violating this panics on the
-/// AVX2 path (bounds-checked buffer copy), but on the scalar fallback in a
-/// release build it silently returns a wrong score instead of panicking —
-/// the match-bit shift (`1 << i`) overflows a `u64` and wraps once
-/// overflow checks are off.
-#[inline]
-pub(crate) unsafe fn jaro_winkler_unchecked(a: &[u8], b: &[u8]) -> f32 {
-    debug_assert!(a.len() <= 64 && b.len() <= 64);
-
-    #[cfg(all(not(feature = "avx2"), target_arch = "x86_64"))]
-    if is_x86_feature_detected!("avx2") {
-        // SAFETY: AVX2 availability just checked; caller guarantees length <= 64.
-        return unsafe { avx2::jaro_winkler(a, b) };
-    }
-
-    #[cfg(feature = "avx2")]
-    // SAFETY: the `avx2` feature asserts AVX2 is available; caller guarantees length <= 64.
-    return unsafe { avx2::jaro_winkler(a, b) };
-
-    #[cfg(not(feature = "avx2"))]
-    crate::jaro_winkler_bytes(a, b)
+    unsafe { crate::jaro_winkler_unchecked(a_bytes, b_bytes) }
 }
 
 #[cfg(test)]

--- a/packages/fuzzy/src/simd.rs
+++ b/packages/fuzzy/src/simd.rs
@@ -1,0 +1,257 @@
+use crate::ToBytes;
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) mod avx2 {
+    use std::arch::x86_64::{
+        __m256i, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
+    };
+
+    /// Mask with bits `[0, n)` set. `n` must be in `1..=64`.
+    #[inline]
+    fn low_bits(n: usize) -> u64 {
+        debug_assert!((1..=64).contains(&n));
+        u64::MAX >> (64 - n)
+    }
+
+    /// Combine two 32-lane byte-compare results into one 64-bit position mask.
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    // The i32 movemask result is a 32-bit lane bitmask, not a signed
+    // quantity: reinterpreting its bits as u32 (then widening to u64) is
+    // intentional, not a lossy numeric cast.
+    #[allow(clippy::cast_sign_loss, clippy::cast_lossless)]
+    fn movemask64(lo: __m256i, hi: __m256i) -> u64 {
+        let lo = _mm256_movemask_epi8(lo) as u32 as u64;
+        let hi = _mm256_movemask_epi8(hi) as u32 as u64;
+        lo | (hi << 32)
+    }
+
+    /// AVX2 Jaro-Winkler over byte slices. Bit-identical to
+    /// [`crate::jaro_winkler_bytes`].
+    ///
+    /// # Safety
+    /// The caller must ensure the CPU supports AVX2 and that both slices are
+    /// at most 64 bytes long.
+    #[target_feature(enable = "avx2")]
+    #[allow(clippy::cast_precision_loss, clippy::cast_possible_wrap)]
+    pub(crate) unsafe fn jaro_winkler(a: &[u8], b: &[u8]) -> f32 {
+        debug_assert!(a.len() <= 64 && b.len() <= 64);
+        let len_a = a.len();
+        let len_b = b.len();
+
+        if len_a == 0 && len_b == 0 {
+            return 1.0;
+        }
+        if len_a == 0 || len_b == 0 {
+            return 0.0;
+        }
+
+        // Zero-padded copies so each whole string fits in two YMM registers.
+        let mut a_buf = [0u8; 64];
+        let mut b_buf = [0u8; 64];
+        a_buf[..len_a].copy_from_slice(a);
+        b_buf[..len_b].copy_from_slice(b);
+
+        // SAFETY: both buffers are 64 bytes; loadu has no alignment requirement.
+        let (a_lo, a_hi, b_lo, b_hi) = unsafe {
+            (
+                _mm256_loadu_si256(a_buf.as_ptr().cast()),
+                _mm256_loadu_si256(a_buf.as_ptr().add(32).cast()),
+                _mm256_loadu_si256(b_buf.as_ptr().cast()),
+                _mm256_loadu_si256(b_buf.as_ptr().add(32).cast()),
+            )
+        };
+
+        // Positions where a and b agree byte-for-byte (padding included).
+        let eq_mask = movemask64(_mm256_cmpeq_epi8(a_lo, b_lo), _mm256_cmpeq_epi8(a_hi, b_hi));
+        if len_a == len_b && eq_mask == u64::MAX {
+            return 1.0;
+        }
+
+        let max_dist = (len_a.max(len_b) / 2).saturating_sub(1);
+        let b_valid = low_bits(len_b);
+
+        let mut matches: u32 = 0;
+        let mut hash_a: u64 = 0;
+        let mut hash_b: u64 = 0;
+
+        for i in 0..len_a {
+            // SAFETY: i < len_a <= 64.
+            let c = unsafe { *a_buf.get_unchecked(i) };
+            let needle = _mm256_set1_epi8(c as i8);
+            let eq = movemask64(
+                _mm256_cmpeq_epi8(needle, b_lo),
+                _mm256_cmpeq_epi8(needle, b_hi),
+            );
+
+            let start = i.saturating_sub(max_dist);
+            let window = (u64::MAX << start) & low_bits((i + max_dist + 1).min(64)) & b_valid;
+
+            let candidates = eq & window & !hash_b;
+            if candidates != 0 {
+                hash_a |= 1 << i;
+                // Greedy first fit: lowest candidate bit, same as the scalar loop.
+                hash_b |= candidates & candidates.wrapping_neg();
+                matches += 1;
+            }
+        }
+
+        if matches == 0 {
+            return 0.0;
+        }
+
+        let mut transpositions: u32 = 0;
+        let mut a_matches = hash_a;
+        let mut b_matches = hash_b;
+        while a_matches != 0 {
+            let i = a_matches.trailing_zeros() as usize;
+            let j = b_matches.trailing_zeros() as usize;
+            a_matches &= a_matches - 1;
+            b_matches &= b_matches - 1;
+            // SAFETY: i and j are bit positions of u64 masks, so < 64.
+            if unsafe { a_buf.get_unchecked(i) != b_buf.get_unchecked(j) } {
+                transpositions += 1;
+            }
+        }
+
+        // Common prefix from the equality mask, clamped to the shorter length
+        // so zero padding can never extend it past real bytes.
+        let neq = !eq_mask | !low_bits(len_a.min(len_b));
+        let prefix_len = neq.trailing_zeros().min(4) as f32;
+
+        let matches = matches as f32;
+        let jaro_similarity = (1.0 / 3.0)
+            * (matches / len_a as f32
+                + matches / len_b as f32
+                + (matches - transpositions as f32 / 2.0) / matches);
+
+        let scaling_factor = 0.1;
+        jaro_similarity + (prefix_len * scaling_factor * (1.0 - jaro_similarity))
+    }
+}
+
+/// Jaro-Winkler over ASCII bytes, dispatching to an AVX2 kernel when the CPU
+/// supports it and falling back to the scalar bitmask core otherwise.
+///
+/// Scores are bit-identical to [`crate::jaro_winkler_ascii_bitmask`]; inputs
+/// longer than 64 bytes are truncated to their first 64 bytes.
+#[must_use]
+pub fn jaro_winkler_ascii_simd<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
+    let a_bytes = a.to_bytes();
+    let b_bytes = b.to_bytes();
+    let a_chars = &a_bytes[..a_bytes.len().min(64)];
+    let b_chars = &b_bytes[..b_bytes.len().min(64)];
+
+    #[cfg(target_arch = "x86_64")]
+    if is_x86_feature_detected!("avx2") {
+        // SAFETY: AVX2 availability just checked; slices truncated to <= 64 bytes above.
+        return unsafe { avx2::jaro_winkler(a_chars, b_chars) };
+    }
+
+    crate::jaro_winkler_bytes(a_chars, b_chars)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::jaro_winkler_ascii_simd;
+
+    // Deterministic pseudo-random corpus (no dev-dependency needed).
+    fn lcg_corpus() -> Vec<String> {
+        let mut state: u64 = 0x243F_6A88_85A3_08D3;
+        let alphabet = b"abcdefghijklmnopqrstuvwxyz 0123456789";
+        let mut out = Vec::new();
+        for len in [0usize, 1, 2, 5, 11, 18, 31, 57, 63, 64, 70, 100] {
+            for _ in 0..8 {
+                let s: String = (0..len)
+                    .map(|_| {
+                        state = state
+                            .wrapping_mul(6_364_136_223_846_793_005)
+                            .wrapping_add(1_442_695_040_888_963_407);
+                        char::from(alphabet[(state >> 33) as usize % alphabet.len()])
+                    })
+                    .collect();
+                out.push(s);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn test_simd_matches_bitmask_on_corpus() {
+        let corpus = lcg_corpus();
+        for a in &corpus {
+            for b in &corpus {
+                let expected = crate::jaro_winkler_ascii_bitmask(a, b);
+                let actual = jaro_winkler_ascii_simd(a, b);
+                assert_eq!(actual, expected, "mismatch for {a:?} vs {b:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_simd_known_score() {
+        // Same fixture as the bitmask test suite: exact score must match.
+        assert_eq!(jaro_winkler_ascii_simd(&"CRATE", &"TRACE"), 0.733_333_35);
+    }
+
+    #[test]
+    fn test_simd_identical() {
+        assert_eq!(
+            jaro_winkler_ascii_simd(&"lightning bolt", &"lightning bolt"),
+            1.0
+        );
+    }
+
+    #[test]
+    fn test_simd_empty_both() {
+        assert_eq!(jaro_winkler_ascii_simd(&"", &""), 1.0);
+    }
+
+    #[test]
+    fn test_simd_one_empty() {
+        assert_eq!(jaro_winkler_ascii_simd(&"card", &""), 0.0);
+    }
+
+    #[test]
+    fn test_simd_no_matches() {
+        assert_eq!(jaro_winkler_ascii_simd(&"abc", &"xyz"), 0.0);
+    }
+
+    #[test]
+    fn test_simd_over_64_bytes_truncates() {
+        let a = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg1234567890";
+        let b = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg0987654321";
+        assert_eq!(jaro_winkler_ascii_simd(&a, &b), 1.0);
+    }
+
+    #[test]
+    fn test_simd_embedded_nul_matches_bitmask() {
+        // NUL never occurs in normalised input, but the two implementations
+        // must still agree so equivalence is unconditional.
+        let a = "ab\0";
+        let b = "ab";
+        assert_eq!(
+            jaro_winkler_ascii_simd(&a, &b),
+            crate::jaro_winkler_ascii_bitmask(&a, &b)
+        );
+    }
+
+    #[test]
+    fn test_simd_accepts_string_type() {
+        let a = String::from("black lotus");
+        let b = String::from("black lotos");
+        assert!(jaro_winkler_ascii_simd(&a, &b) > 0.9);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_avx2_kernel_directly() {
+        if !is_x86_feature_detected!("avx2") {
+            eprintln!("skipping: AVX2 not available on this CPU");
+            return;
+        }
+        // SAFETY: AVX2 availability checked above; inputs are <= 64 bytes.
+        let score = unsafe { super::avx2::jaro_winkler(b"CRATE", b"TRACE") };
+        assert_eq!(score, 0.733_333_35);
+    }
+}

--- a/packages/fuzzy/src/simd.rs
+++ b/packages/fuzzy/src/simd.rs
@@ -1,5 +1,8 @@
 use crate::ToBytes;
 
+#[cfg(all(feature = "avx2", not(target_arch = "x86_64")))]
+compile_error!("fuzzy's `avx2` feature requires target_arch = \"x86_64\"");
+
 #[cfg(target_arch = "x86_64")]
 pub(crate) mod avx2 {
     use std::arch::x86_64::{
@@ -125,8 +128,7 @@ pub(crate) mod avx2 {
                 + matches / len_b as f32
                 + (matches - transpositions as f32 / 2.0) / matches);
 
-        let scaling_factor = 0.1;
-        jaro_similarity + (prefix_len * scaling_factor * (1.0 - jaro_similarity))
+        jaro_similarity + (prefix_len * 0.1 * (1.0 - jaro_similarity))
     }
 }
 
@@ -142,18 +144,44 @@ pub fn jaro_winkler_ascii_simd<A: ToBytes, B: ToBytes>(a: &A, b: &B) -> f32 {
 
 /// Slice-level entry point for the same dispatch: safe for slices of any
 /// length (truncates to 64 bytes internally before the kernel).
+///
+/// With the `avx2` feature enabled, the runtime `is_x86_feature_detected!`
+/// check is skipped and the AVX2 kernel is called unconditionally — only
+/// enable that feature when the deployment CPU is known to support AVX2
+/// (see `fuzzy/Cargo.toml`).
 #[must_use]
+#[inline]
 pub(crate) fn jaro_winkler_slices(a: &[u8], b: &[u8]) -> f32 {
     let a_chars = &a[..a.len().min(64)];
     let b_chars = &b[..b.len().min(64)];
+    // SAFETY: truncated to <= 64 bytes above.
+    unsafe { jaro_winkler_unchecked(a_chars, b_chars) }
+}
 
-    #[cfg(target_arch = "x86_64")]
+/// AVX2/scalar dispatch, skipping the length truncation `jaro_winkler_slices` does.
+///
+/// # Safety
+/// `a` and `b` must each be at most 64 bytes. Violating this panics on the
+/// AVX2 path (bounds-checked buffer copy), but on the scalar fallback in a
+/// release build it silently returns a wrong score instead of panicking —
+/// the match-bit shift (`1 << i`) overflows a `u64` and wraps once
+/// overflow checks are off.
+#[inline]
+pub(crate) unsafe fn jaro_winkler_unchecked(a: &[u8], b: &[u8]) -> f32 {
+    debug_assert!(a.len() <= 64 && b.len() <= 64);
+
+    #[cfg(all(not(feature = "avx2"), target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx2") {
-        // SAFETY: AVX2 availability just checked; slices truncated to <= 64 bytes above.
-        return unsafe { avx2::jaro_winkler(a_chars, b_chars) };
+        // SAFETY: AVX2 availability just checked; caller guarantees length <= 64.
+        return unsafe { avx2::jaro_winkler(a, b) };
     }
 
-    crate::jaro_winkler_bytes(a_chars, b_chars)
+    #[cfg(feature = "avx2")]
+    // SAFETY: the `avx2` feature asserts AVX2 is available; caller guarantees length <= 64.
+    return unsafe { avx2::jaro_winkler(a, b) };
+
+    #[cfg(not(feature = "avx2"))]
+    crate::jaro_winkler_bytes(a, b)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
  
  Adds a hand-written AVX2 implementation of Jaro-Winkler to the `fuzzy` crate,
  restructures the crate for clarity, and routes the bot's card search / guess
  matching through the accelerated path. Scores are bit-identical to the existing
  scalar implementation — this is a performance and structure change, not a
  behavioural one.

## `fuzzy` crate

  - **New AVX2 kernel** (`simd.rs`): `jaro_winkler_ascii_simd` scores a pair using
    an AVX2 kernel, dispatching via a cached runtime `is_x86_feature_detected!`
    check and falling back to the scalar kernel when AVX2 is absent. Verified
    bit-identical to the scalar path by a deterministic corpus equivalence test.
  - **Module split**: `bmask.rs` (scalar u64-bitmask reference), `simd.rs` (AVX2
    kernel + SIMD entry point), `lib.rs` (dispatch, `winkliest_match` /
    `winkliest_sort`, `ToBytes`, shared truncation helpers). Added crate-level
    docs covering the ASCII/pre-normalised and 64-byte-truncation contracts.
  - **Opt-in `avx2` feature**: skips the per-call runtime check and calls the AVX2
    kernel unconditionally, for deployments on known-AVX2 hardware. Rejected at
    compile time on non-`x86_64` targets. The default build stays portable.

## Bot

  - Card picking now delegates to `fuzzy::winkliest_sort` via a local `CardByName`
    newtype, replacing the hand-rolled scoring/sort in `fuzzy_sort`.
  - Passthrough `avx2` feature (`avx2 = ["fuzzy/avx2"]`); the Docker image builds
    with `--features avx2`. AVX2 confirmed present on the deployment node *and*
    inside the running pod, so the unconditional-AVX2 build is safe there. A
    non-AVX2 CPU/VM (e.g. a Proxmox `kvm64` guest) would SIGILL — drop the feature
    from the Dockerfile if the deploy hardware ever changes.
    
## Build / CI
  
  - `pr.yml` gains a `cargo test -p fuzzy --features avx2` step so CI exercises the
    feature-on dispatch branch the deployed image actually uses (GitHub's x86_64
    runners have AVX2). 
  - Benchmarks added: SIMD vs bitmask vs `strsim`, plus `winkliest` match/sort.
  
## Testing
  
  - 52 `fuzzy` tests pass in both the default and `--features avx2` configs.
  - Includes the SIMD/scalar corpus equivalence test, tie-break ordering, and a
    `debug_assert` contract guard on the unchecked kernel entry.
  - `cargo fmt --check` and `cargo clippy` clean.